### PR TITLE
PersistControl cleanup

### DIFF
--- a/packages/ui/src/components/PersistControl.tsx
+++ b/packages/ui/src/components/PersistControl.tsx
@@ -1,27 +1,49 @@
-import cn from 'classnames'
-import { ContentStatus, SaveControl } from '.'
+import classNames from 'classnames'
+import { ReactNode } from 'react'
+import { Icon, SaveControl, Spinner } from '.'
 import { useClassNamePrefix } from '../auxiliary'
+import { toEnumStateClass } from '../utils'
 
 export interface PersistControlProps {
+	label?: ReactNode
+	labelSaved ?: ReactNode
 	isMutating: boolean
 	isDirty: boolean
 	onSave: () => void
 }
 
-export function PersistControl({ isMutating, isDirty, onSave }: PersistControlProps) {
+export function PersistControl({
+	isDirty,
+	isMutating,
+	label,
+	labelSaved,
+	onSave,
+}: PersistControlProps) {
 	const prefix = useClassNamePrefix()
-
 	const isDisabled = isMutating || !isDirty
+	const classList = classNames(
+		`${prefix}persistControl`,
+		toEnumStateClass(isDirty ? 'dirty' : undefined),
+		toEnumStateClass(isDisabled ? 'disabled' : undefined),
+		toEnumStateClass(isMutating ? 'mutating' : undefined),
+	)
 
-	const message = isMutating ? 'Saving…' : !isDirty ? 'All saved' : 'Unsaved changes'
+	const labelSavedText = labelSaved ?? 'Saved'
+	const labelSaveText = label ?? 'Save'
+
+	const isSaved = isDirty || isMutating
 
 	return (
-		<div className={`${prefix}persistControl`}>
-			<div className={`${prefix}persistControl-label`}>
-				<ContentStatus label={message} />
-			</div>
-			<SaveControl isPrimaryDisabled={isDisabled} primaryAction="Save" onPrimary={isDisabled ? undefined : onSave} />
-		</div>
+		<SaveControl
+			isPrimaryDisabled={isDisabled}
+			onPrimary={isDisabled ? undefined : onSave}
+			primaryAction={<span className={classList}>
+				<span className={`${prefix}persistControl-label--saved`} aria-hidden={isSaved}>{labelSavedText}</span>
+				<span className={`${prefix}persistControl-label--dirty`} aria-hidden={!isSaved}>{labelSaveText}</span>
+				<span className={`${prefix}persistControl-icon`} aria-hidden={isSaved}><Icon blueprintIcon={'tick'} /></span>
+				{isMutating && <Spinner />}
+			</span>}
+		/>
 	)
 }
 PersistControl.displayName = 'PersistControl'

--- a/packages/ui/src/styles/_variables.scss
+++ b/packages/ui/src/styles/_variables.scss
@@ -1,6 +1,10 @@
 @import './../../node_modules/@mangoweb/sass-base/_variables';
 @import './functions/index';
 
+// Diameter of rounded objects is larger
+$extra-optical-size-rounded-rectangle: 0.2146;
+$extra-optical-size-circle: 0.1284;
+
 // "CUI" stands for Contember UI
 
 // Core configurations

--- a/packages/ui/src/styles/components/persistControl.sass
+++ b/packages/ui/src/styles/components/persistControl.sass
@@ -1,12 +1,69 @@
+@use 'sass:math'
+
 @import '../common'
 
 .#{$cui-conf-globalPrefix}persistControl
-	display: inline-flex
-	align-items: center
-	background: rgba(#ddd, .5)
-	border-radius: 3em
-	padding-left: .5em
+	$icon-size: 2em
+	$label-transition-duration: .2s
+	$check-transition-duration: .1s
 
-	&-label
-		margin-left: 1em
-		margin-right: .75em
+	align-items: center
+	display: flex
+	gap: 1.25em
+	position: relative
+
+	.cui-spinner,
+	&-label--dirty
+		left: 0
+		right: 0
+		bottom: 0
+		top: 0
+		margin: auto
+		position: absolute
+
+	&-label--dirty
+		opacity: 0
+		transform: translateX(-1em)
+		transition-property: opacity, transform
+		transition-duration: $label-transition-duration, $label-transition-duration
+
+	&-label--saved
+		margin: 0 auto
+		transition-property: opacity, transform
+		transition-duration: $label-transition-duration, $label-transition-duration
+
+		.is-dirty &,
+		.is-mutating &
+			opacity: 0
+			transform: translateX(1em)
+
+	.is-dirty &-label--dirty
+		opacity: 1
+		transform: translateX(0)
+
+	.is-dirty.is-mutating &-label--dirty
+		opacity: 0
+
+	&-icon
+		align-items: center
+		background: darken($cui-color-success, 5%)
+		color: $cui-control-view-default-background
+		display: flex
+		justify-content: center
+		height: $icon-size
+		width: $icon-size
+		border-radius: 50%
+		margin: -0.5em -1em -0.5em (-1 * $icon-size * $extra-optical-size-circle)
+		vertical-align: bottom
+		transition-property: opacity, transform
+		transition-duration: $check-transition-duration, $check-transition-duration
+		transition-delay: $check-transition-duration
+		transition-timing-function: ease-out
+
+		.is-dirty &,
+		.is-mutating &
+			opacity: 0
+			transform: scale(0.25) rotate(135deg)
+
+		.#{$cui-conf-globalPrefix}icon
+			vertical-align: bottom

--- a/packages/ui/src/styles/components/saveControl.sass
+++ b/packages/ui/src/styles/components/saveControl.sass
@@ -2,10 +2,17 @@
 
 @import '../common'
 
-$saveControl-color: #0094FF
-$saveControl-color-alt: #FFFFFF
+$saveControl-color: $cui-button-view-primary-background
+$saveControl-color-alt: $cui-button-view-primary-color
 
 .#{$cui-conf-globalPrefix}saveControl
+	$vertical-padding: .8em
+	$horizontal-padding: 1.5em
+	$line-height: 1
+
+	$button-height: $line-height + 2 * $vertical-padding
+
+	display: inline-flex
 	position: relative
 
 	&-window-in
@@ -13,7 +20,7 @@ $saveControl-color-alt: #FFFFFF
 
 	&-button-primary,
 	&-button-toggle
-		padding: .8em 1.5em
+		padding: $vertical-padding $horizontal-padding
 
 	&-button,
 	&-window
@@ -22,13 +29,19 @@ $saveControl-color-alt: #FFFFFF
 	&-button
 		background: $saveControl-color
 		color: $saveControl-color-alt
-		display: inline-flex
-		line-height: 1
+		display: inherit
+		flex-grow: 1
+		line-height: $line-height
 		overflow: hidden
+		margin-left: -$button-height * math.div($extra-optical-size-rounded-rectangle, 2)
+		margin-right: -$button-height * math.div($extra-optical-size-rounded-rectangle, 2)
 
 		&.view-disabled
-			background: #aaaaaa
+			background: rgba(182, 182, 182, 0.5)
 			pointer-events: none
+
+		&-primary
+			flex-grow: inherit
 
 		&-primary,
 		&-toggle

--- a/packages/ui/stories/src/PersistControl.stories.tsx
+++ b/packages/ui/stories/src/PersistControl.stories.tsx
@@ -1,0 +1,52 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react'
+import * as React from 'react'
+import { Aether, PersistControl } from '../../src'
+
+export default {
+	title: 'PersistControl',
+	component: PersistControl,
+	decorators: [
+		Story => (<>
+			<p>Container set to align children flex-start:</p>
+			<Aether style={{ display: 'flex', gap: '1em', justifyContent: 'flex-start', padding: '2em' }}>
+					<Story />
+			</Aether>
+
+			<p>Container set align children center:</p>
+			<Aether style={{ display: 'flex', gap: '1em', justifyContent: 'center', padding: '2em' }}>
+					<Story />
+			</Aether>
+
+			<p>Container set to align children flex-end:</p>
+			<Aether style={{ display: 'flex', gap: '1em', justifyContent: 'flex-end', padding: '2em' }}>
+					<Story />
+			</Aether>
+
+			<p>Container set to stretch children:</p>
+			<Aether style={{ display: 'flex', flexDirection: 'column', gap: '1em', padding: '2em' }}>
+				<Story />
+			</Aether>
+			</>
+		),
+	],
+} as ComponentMeta<typeof PersistControl>
+
+const Template: ComponentStory<typeof PersistControl> = args => <PersistControl {...args} />
+
+export const Defaut = Template.bind({})
+
+Defaut.args = {
+	isDirty: false,
+	isMutating: false,
+	onSave: () => console.log('Save'),
+}
+
+export const Translated = Template.bind({})
+
+Translated.args = {
+	isDirty: false,
+	isMutating: false,
+	label: 'Uložit',
+	labelSaved: 'Uloženo',
+	onSave: () => console.log('Save'),
+}


### PR DESCRIPTION
Removes noisy "save" button parts

- Add props to change label based on state (dirty, mutating)
- Add spinner, animate check tick and labels
- Removes clock icon
- Changes disabled grey colour of the `SaveControl` button
- Fixes optical margin issue of the `SaveControl` button
- Stretches `SaveControl` button based on the parent container

Closes #16 

### Checks
- [x] The changes and implementation strategy have been consulted with the maintainers.
- [x] The code passes all the checks (Run `pnpm run check`).
