### PR TITLE
Add `ActionableBox` to Storybook and fix focus within

### DIFF
--- a/packages/ui/src/styles/components/actionableBox.sass
+++ b/packages/ui/src/styles/components/actionableBox.sass
@@ -16,7 +16,6 @@
 
 		transition-property: opacity, visibility, pointer-events, transform
 		transition-duration: .1s
-		visibility: hidden
 		opacity: 0
 		pointer-events: none
 		transform: translateY(em(-10px))
@@ -26,9 +25,8 @@
 		& + &
 			margin-top: em(5px)
 
-	&:hover > &
-		&-actions
-			visibility: visible
-			opacity: 1
-			pointer-events: all
-			transform: translateY(0)
+	&:hover > &-actions,
+	&:focus-within > &-actions
+		opacity: 1
+		pointer-events: all
+		transform: translateY(0)

--- a/packages/ui/stories/src/ActionableBox.stories.tsx
+++ b/packages/ui/stories/src/ActionableBox.stories.tsx
@@ -1,0 +1,35 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react'
+import * as React from 'react'
+import { ActionableBox, Aether } from '../../src'
+
+export default {
+	title: 'ActionableBox',
+	component: ActionableBox,
+	decorators: [
+		Story => (
+			<Aether style={{ alignItems: 'flex-start', display: 'flex', flexDirection: 'column', gap: '1em', padding: '2em' }}>
+				<button>focusable before</button>
+				<Story />
+				<button>focusable after</button>
+			</Aether>
+		),
+	],
+} as ComponentMeta<typeof ActionableBox>
+
+const Template: ComponentStory<typeof ActionableBox> = args => <ActionableBox {...args} />
+
+const loremIpsum =
+	'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequatur provident, quis? Ad adipisci dolore ipsam\n' +
+	'magnam modi nostrum optio quia velit! Ab aperiam consequatur consequuntur deleniti iusto libero possimus\n' +
+	'tpraesentium.'
+
+export const Simple = Template.bind({})
+
+Simple.args = {
+	editContents: <div style={{ display: 'flex', flexDirection: 'column' }}>
+		<input />
+		<input />
+		<button>Click</button>
+	</div>,
+	children: loremIpsum,
+}


### PR DESCRIPTION
Add `ActionableBox` to Storybook and fix keyboard tabbing within the container.

Note: Internal `ActionableBoxContent` component was created to be able to use focus hook (same order of hooks rule).

### Checks
- [x] The changes and implementation strategy have been consulted with the maintainers.
- [x] The code passes all the checks (Run `pnpm run check`).
