### PR TITLE
Add `Button` to Storyboard

### DIFF
--- a/packages/ui/src/components/forms/ButtonList.tsx
+++ b/packages/ui/src/components/forms/ButtonList.tsx
@@ -1,16 +1,23 @@
 import cn from 'classnames'
 import { memo, ReactNode } from 'react'
 import { useComponentClassName } from '../../auxiliary'
-import type { ButtonListFlow } from '../../types'
+import type { ButtonGroupOrientation, ButtonListFlow, Size } from '../../types'
 import { toEnumViewClass } from '../../utils'
 
 export interface ButtonListProps {
 	children?: ReactNode
 	flow?: ButtonListFlow
+	size?: Size
+	orientation?: ButtonGroupOrientation
 }
 
-export const ButtonList = memo(({ children, flow }: ButtonListProps) => (
-	<div className={cn(useComponentClassName('button-list'), toEnumViewClass(flow, 'inline'))} role="group">
+export const ButtonList = memo(({ children, flow, orientation, size }: ButtonListProps) => (
+	<div className={cn(
+		useComponentClassName('button-list'),
+		toEnumViewClass(size),
+		toEnumViewClass(orientation, 'horizontal'),
+		toEnumViewClass(flow, 'inline'),
+	)} role="group">
 		{children}
 	</div>
 ))

--- a/packages/ui/src/styles/_variables.scss
+++ b/packages/ui/src/styles/_variables.scss
@@ -18,6 +18,7 @@ $cui-color-pink: #FF25C3 !default;
 $cui-color-purple: #9013FE !default;
 $cui-color-green: #7ED321 !default;
 $cui-color-yellow: #FFC416 !default;
+$cui-color-orange: #FF7316 !default;
 $cui-color-red: #FF312E !default;
 
 $cui-color-white: #FFFFFF !default;
@@ -39,7 +40,7 @@ $cui-color-primary: $cui-color-blue !default;
 $cui-color-secondary: $cui-color-pink !default;
 $cui-color-tertiary: $cui-color-purple !default;
 $cui-color-success: $cui-color-green !default;
-$cui-color-warn: $cui-color-yellow !default;
+$cui-color-warn: $cui-color-orange !default;
 $cui-color-danger: $cui-color-red !default;
 $cui-color-info: $cui-color-blue !default;
 $cui-color-dark: $cui-color-gray-8 !default;
@@ -53,7 +54,9 @@ $cui-base-lineHeight: 1.2 !default; // In order for computations to work, keep t
 $cui-effect-transition-duration: .3s !default;
 
 $cui-control-border-width: em(1px) !default;
-$cui-control-border-radius: em(3px) !default;
+$cui-control-border-radius: em(5px) !default;
+
+$cui-control-focus-opacity: 0.3 !default;
 
 $cui-control-view-default-color: $cui-color-gray-7 !default;
 $cui-control-view-default-background: $cui-color-white !default;
@@ -138,92 +141,111 @@ $cui-select-chevron-height: .5em !default;
 $cui-button-effect-transition-duration: .15s !default;
 
 $cui-button-bland-opacity: .75 !default;
+$cui-button-disabled-background-color: $cui-color-gray-2 !default;
+$cui-button-disabled-border-color: $cui-color-gray-2 !default;
+$cui-button-disabled-color: $cui-color-gray-5 !default;
 
 $cui-button-view-default-color: $cui-color-gray-7 !default;
 $cui-button-view-default-background: $cui-color-gray-1 !default;
-$cui-button-view-default-border-color: $cui-color-gray-3 !default;
+$cui-button-view-default-border-color: $cui-color-gray-2 !default;
+$cui-button-view-default-focus-color: $cui-control-view-default-distinction-color !default;
 $cui-button-view-default-distinction-color: $cui-color-gray-7 !default;
 $cui-button-view-default: (
 	'color': $cui-button-view-default-color,
 	'background': $cui-button-view-default-background,
 	'borderColor': $cui-button-view-default-border-color,
+	'focusColor': $cui-button-view-default-focus-color,
 	'distinctionColor': $cui-button-view-default-distinction-color,
 ) !default;
 
 $cui-button-view-primary-color: $cui-color-white !default;
 $cui-button-view-primary-background: $cui-color-primary !default;
-$cui-button-view-primary-border-color: darken($cui-color-primary, 5) !default;
+$cui-button-view-primary-border-color: darken($cui-color-primary, 10) !default;
+$cui-button-view-primary-focus-color: $cui-color-primary !default;
 $cui-button-view-primary-distinction-color: $cui-color-primary !default;
 $cui-button-view-primary: (
 	'color': $cui-button-view-primary-color,
 	'background': $cui-button-view-primary-background,
 	'borderColor': $cui-button-view-primary-border-color,
+	'focusColor': $cui-button-view-primary-focus-color,
 	'distinctionColor': $cui-button-view-primary-distinction-color,
 ) !default;
 
 $cui-button-view-secondary-color: $cui-color-white !default;
 $cui-button-view-secondary-background: $cui-color-secondary !default;
-$cui-button-view-secondary-border-color: darken($cui-color-secondary, 5) !default;
+$cui-button-view-secondary-border-color: darken($cui-color-secondary, 15) !default;
+$cui-button-view-secondary-focus-color: $cui-color-secondary !default;
 $cui-button-view-secondary-distinction-color: $cui-color-secondary !default;
 $cui-button-view-secondary: (
 	'color': $cui-button-view-secondary-color,
 	'background': $cui-button-view-secondary-background,
 	'borderColor': $cui-button-view-secondary-border-color,
+	'focusColor': $cui-button-view-secondary-focus-color,
 	'distinctionColor': $cui-button-view-secondary-distinction-color,
 ) !default;
 
 $cui-button-view-tertiary-color: $cui-color-white !default;
 $cui-button-view-tertiary-background: $cui-color-tertiary !default;
-$cui-button-view-tertiary-border-color: darken($cui-color-tertiary, 5) !default;
+$cui-button-view-tertiary-border-color: darken($cui-color-tertiary, 15) !default;
+$cui-button-view-tertiary-focus-color: $cui-color-tertiary !default;
 $cui-button-view-tertiary-distinction-color: $cui-color-tertiary !default;
 $cui-button-view-tertiary: (
 	'color': $cui-button-view-tertiary-color,
 	'background': $cui-button-view-tertiary-background,
 	'borderColor': $cui-button-view-tertiary-border-color,
+	'focusColor': $cui-button-view-tertiary-focus-color,
 	'distinctionColor': $cui-button-view-tertiary-distinction-color,
 ) !default;
 
 $cui-button-view-success-color: $cui-color-white !default;
-$cui-button-view-success-background: $cui-color-success !default;
-$cui-button-view-success-border-color: darken($cui-color-success, 5) !default;
-$cui-button-view-success-distinction-color: $cui-color-success !default;
+$cui-button-view-success-background: darken($cui-color-success, 10) !default;
+$cui-button-view-success-border-color: darken($cui-color-success, 15) !default;
+$cui-button-view-success-focus-color: darken($cui-color-success, 10) !default;
+$cui-button-view-success-distinction-color: darken($cui-color-success, 10) !default;
 $cui-button-view-success: (
 	'color': $cui-button-view-success-color,
 	'background': $cui-button-view-success-background,
 	'borderColor': $cui-button-view-success-border-color,
+	'focusColor': $cui-button-view-success-focus-color,
 	'distinctionColor': $cui-button-view-success-distinction-color,
 ) !default;
 
 $cui-button-view-warn-color: $cui-color-white !default;
 $cui-button-view-warn-background: $cui-color-warn !default;
-$cui-button-view-warn-border-color: darken($cui-color-warn, 5) !default;
+$cui-button-view-warn-border-color: darken($cui-color-warn, 10) !default;
+$cui-button-view-warn-focus-color: $cui-color-warn !default;
 $cui-button-view-warn-distinction-color: $cui-color-warn !default;
 $cui-button-view-warn: (
 	'color': $cui-button-view-warn-color,
 	'background': $cui-button-view-warn-background,
 	'borderColor': $cui-button-view-warn-border-color,
+	'focusColor': $cui-button-view-warn-focus-color,
 	'distinctionColor': $cui-button-view-warn-distinction-color,
 ) !default;
 
 $cui-button-view-danger-color: $cui-color-white !default;
 $cui-button-view-danger-background: $cui-color-danger !default;
-$cui-button-view-danger-border-color: darken($cui-color-danger, 5) !default;
+$cui-button-view-danger-border-color: darken($cui-color-danger, 15) !default;
+$cui-button-view-danger-focus-color: $cui-color-danger !default;
 $cui-button-view-danger-distinction-color: $cui-color-danger !default;
 $cui-button-view-danger: (
 	'color': $cui-button-view-danger-color,
 	'background': $cui-button-view-danger-background,
 	'borderColor': $cui-button-view-danger-border-color,
+	'focusColor': $cui-button-view-danger-focus-color,
 	'distinctionColor': $cui-button-view-danger-distinction-color,
 ) !default;
 
 $cui-button-view-dark-color: $cui-color-gray-2 !default;
 $cui-button-view-dark-background: $cui-color-dark !default;
-$cui-button-view-dark-border-color: darken($cui-color-dark, 5) !default;
+$cui-button-view-dark-border-color: darken($cui-color-dark, 15) !default;
+$cui-button-view-dark-focus-color: $cui-color-dark !default;
 $cui-button-view-dark-distinction-color: $cui-color-dark !default;
 $cui-button-view-dark: (
 	'color': $cui-button-view-dark-color,
 	'background': $cui-button-view-dark-background,
 	'borderColor': $cui-button-view-dark-border-color,
+	'focusColor': $cui-button-view-dark-focus-color,
 	'distinctionColor': $cui-button-view-dark-distinction-color,
 ) !default;
 

--- a/packages/ui/src/styles/abstract/buttonEssentials.sass
+++ b/packages/ui/src/styles/abstract/buttonEssentials.sass
@@ -5,7 +5,7 @@
 	font-family: inherit
 	transition-duration: var(--cui-button-effect-transition-duration)
 	transition-property: box-shadow, color, background, opacity, border-color
-	font-weight: $fw-normal
+	font-weight: $fw-medium
 	font-size: inherit
 	text-decoration: none
 	position: relative

--- a/packages/ui/src/styles/abstract/buttonSizeMixin.sass
+++ b/packages/ui/src/styles/abstract/buttonSizeMixin.sass
@@ -1,0 +1,19 @@
+@mixin buttonSizeMixin($fontSize, $height)
+  $c: math.div($fontSize, 1em)
+  $normalizedHeight: math.div($height, $c)
+  $visualLineHeight: $normalizedHeight - 2 * math.div($cui-control-border-width, $c)
+  $actualLineHeight: 1.25em
+  $edgeOffset: ($visualLineHeight - $actualLineHeight) * 0.5
+
+  min-height: $normalizedHeight
+  line-height: $actualLineHeight
+  padding: $edgeOffset .5em
+  font-size: $fontSize
+
+  &.view-squarish,
+  &.view-circular
+    +size($normalizedHeight)
+  &.view-generous,
+  &.view-generousBlock
+    padding-left: 1.5 * $normalizedHeight
+    padding-right: 1.5 * $normalizedHeight

--- a/packages/ui/src/styles/abstract/buttonSizes.sass
+++ b/packages/ui/src/styles/abstract/buttonSizes.sass
@@ -1,32 +1,15 @@
 @use 'sass:math'
 
+@import './buttonSizeMixin'
+
 %buttonSizes
 	@each $name, $settings in $cui-button-sizes
 		$height: map_get($settings, height)
 		$fontSize: map_get($settings, fontSize)
-
 		$view: toView($name)
-		&#{$view},
-		&-group#{$view}
-			$c: math.div($fontSize, 1em)
-			$normalizedHeight: math.div($height, $c)
-			$visualLineHeight: $normalizedHeight - 2 * math.div($cui-control-border-width, $c)
-			$actualLineHeight: 1.25em
-			$edgeOffset: ($visualLineHeight - $actualLineHeight) * 0.5
-			min-height: $normalizedHeight
-			line-height: $actualLineHeight
-			padding: $edgeOffset .5em
-			font-size: $fontSize
 
-
-			&.view-squarish,
-			&.view-circular
-				+size($normalizedHeight)
-			&.view-generous,
-			&.view-generousBlock
-				padding-left: 1.5 * $normalizedHeight
-				padding-right: 1.5 * $normalizedHeight
-
+		&#{$view}
+			@include buttonSizeMixin($fontSize, $height)
 
 	&.view-block,
 	&.view-generousBlock

--- a/packages/ui/src/styles/components/button.sass
+++ b/packages/ui/src/styles/components/button.sass
@@ -27,6 +27,20 @@
 	&-list.view-block
 		display: flex
 
+	&-list.view-vertical
+		align-items: stretch
+		flex-direction: column
+		&.view-block
+			width: 100%
+
+	@each $name, $settings in $cui-button-sizes
+		$height: map_get($settings, height)
+		$fontSize: map_get($settings, fontSize)
+		$view: toView($name)
+		&-group#{$view} &,
+		&-list#{$view} &
+			@include buttonSizeMixin($fontSize, $height)
+
 	&-group
 		display: inline-flex
 		flex-wrap: wrap

--- a/packages/ui/src/styles/components/checkbox.sass
+++ b/packages/ui/src/styles/components/checkbox.sass
@@ -131,7 +131,7 @@
 
 	&.is-focused
 		&::before
-			box-shadow: 0 0 0 .2em rgba($cui-control-view-default-distinction-color, .3)
+			box-shadow: 0 0 0 .2em rgba($cui-control-view-default-distinction-color, $cui-control-focus-opacity)
 	&.is-focused:not(.is-checked)
 		&::before
 			border-color: lighten($cui-control-view-default-distinction-color, 10)
@@ -159,5 +159,4 @@
 			&.is-focused::before
 				color: $color
 				border-color: $borderColor
-				box-shadow: 0 0 0 .2em rgba($borderColor, .3)
-
+				box-shadow: 0 0 0 .2em rgba($borderColor, $cui-control-focus-opacity)

--- a/packages/ui/src/styles/components/radio.sass
+++ b/packages/ui/src/styles/components/radio.sass
@@ -85,7 +85,7 @@
 	&-option.is-checked &-control::after
 		background-color: var(--radio-color)
 	&-option.is-focused &-control::before
-		box-shadow: 0 0 0 .2em rgba($cui-control-view-default-distinction-color, .3)
+		box-shadow: 0 0 0 .2em rgba($cui-control-view-default-distinction-color, $cui-control-focus-opacity)
 	&-option.is-focused:not(.is-checked) &-control::before
 		border-color: lighten($cui-control-view-default-distinction-color, 10)
 	&-option.is-checked &-control::after

--- a/packages/ui/src/styles/mixins/buttonVariants.sass
+++ b/packages/ui/src/styles/mixins/buttonVariants.sass
@@ -10,6 +10,7 @@
 		$background: map_get($settings, background)
 		$borderColor: map_get($settings, borderColor)
 		$distinctionColor: map_get($settings, distinctionColor)
+		$focusColor: map_get($settings, focusColor)
 
 		$view: toView($name)
 
@@ -26,19 +27,19 @@
 				transform: translateZ(-.02em)
 		&#{$view}#{$primary-selector}:not([disabled]):not([readonly]):active#{$secondary-selector},
 		&#{$view}#{$primary-selector}.is-active#{$secondary-selector}
-			background: linear-gradient(to bottom, darken($background, 3), darken($background, 9))
+			background: linear-gradient(to bottom, $borderColor, $borderColor)
 
-		&#{$view}#{$primary-selector}:focus#{$secondary-selector}
+		&#{$view}#{$primary-selector}:focus-visible:focus#{$secondary-selector}
 			@extend %implementsCustomFocusEffects
-			box-shadow: 0 0 0 .2em rgba($borderColor, .4)
+			box-shadow: 0 0 0 .2em rgba($focusColor, $cui-control-focus-opacity)
 
 		&#{$view}#{$primary-selector}[disabled]#{$secondary-selector},
 		&#{$view}#{$primary-selector}[readonly]#{$secondary-selector}
 			cursor: not-allowed
-			color: lighten($color, 5)
+			color: $cui-button-disabled-color
 			// This gradient is silly but it means we can transition to it from other gradients
-			background: linear-gradient(to bottom, lighten($background, 10), lighten($background, 10))
-			border-color: lighten($borderColor, 10)
+			background: linear-gradient(to bottom, $cui-button-disabled-background-color, $cui-button-disabled-background-color)
+			border-color: $cui-button-disabled-border-color
 			opacity: $cui-control-inactive-opacity
 
 		&#{$view}.view-seamless#{$primary-selector}#{$secondary-selector},
@@ -52,10 +53,11 @@
 		&#{$view}.view-outlined#{$primary-selector}:hover#{$secondary-selector},
 		&#{$view}.view-seamless#{$primary-selector}:focus#{$secondary-selector},
 		&#{$view}.view-outlined#{$primary-selector}:focus#{$secondary-selector}
-			color: darken($distinctionColor, 5)
+			color: darken($distinctionColor, 20)
 			background: rgba(lighten($distinctionColor, 20), .3)
 		&#{$view}.view-seamless#{$primary-selector}:not([disabled]):not([readonly]):active#{$secondary-selector},
 		&#{$view}.view-outlined#{$primary-selector}:not([disabled]):not([readonly]):active#{$secondary-selector},
 		&#{$view}.view-seamless#{$primary-selector}:not([disabled]):not([readonly]).is-active#{$secondary-selector},
 		&#{$view}.view-outlined#{$primary-selector}:not([disabled]):not([readonly]).is-active#{$secondary-selector}
 			background: rgba(lighten($distinctionColor, 5), .3)
+			color: darken($distinctionColor, 20)

--- a/packages/ui/stories/src/Button.stories.tsx
+++ b/packages/ui/stories/src/Button.stories.tsx
@@ -1,0 +1,32 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react'
+import * as React from 'react'
+import { Aether, Button } from '../../src'
+
+export default {
+	title: 'Button',
+	component: Button,
+	decorators: [
+		Story => (
+			<Aether style={{ alignItems: 'center', display: 'flex', flexDirection: 'row', flexWrap: 'wrap', gap: '1em', padding: '2em' }}>
+        <p style={{ flex: '100% 1 1' }}>This is a text with normal weight that is not clickable. And here's some <a href="#">link</a> that is clickable. Buttons should have enough clickable visual affordance event when seamless.</p>
+				<Story />
+			</Aether>
+		),
+	],
+} as ComponentMeta<typeof Button>
+
+const Template: ComponentStory<typeof Button> = args => <>
+  <Button {...args}>Default</Button>
+  <Button {...args} intent="primary">Primary</Button>
+  <Button {...args} intent="secondary">Secondary</Button>
+  <Button {...args} intent="tertiary">Tertiary</Button>
+  <Button {...args} intent="success">Success</Button>
+  <Button {...args} intent="warn">Warn</Button>
+  <Button {...args} intent="danger">Danger</Button>
+  <Button {...args} intent="dark">Dark</Button>
+</>
+
+export const Default = Template.bind({})
+
+Default.args = {
+}

--- a/packages/ui/stories/src/ButtonGroup.stories.tsx
+++ b/packages/ui/stories/src/ButtonGroup.stories.tsx
@@ -1,0 +1,31 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react'
+import * as React from 'react'
+import { Aether, Button, ButtonGroup } from '../../src'
+
+export default {
+	title: 'ButtonGroup',
+	component: ButtonGroup,
+	decorators: [
+		Story => (
+			<Aether style={{ alignItems: 'center', display: 'flex', flexDirection: 'row', flexWrap: 'wrap', gap: '1em', padding: '2em' }}>
+				<Story />
+			</Aether>
+		),
+	],
+} as ComponentMeta<typeof ButtonGroup>
+
+const Template: ComponentStory<typeof ButtonGroup> = args => <ButtonGroup {...args}>
+  <Button>Default</Button>
+  <Button intent="primary">Primary</Button>
+  <Button intent="secondary">Secondary</Button>
+  <Button intent="tertiary">Tertiary</Button>
+  <Button intent="success">Success</Button>
+  <Button intent="warn">Warn</Button>
+  <Button intent="danger">Danger</Button>
+  <Button intent="dark">Dark</Button>
+</ButtonGroup>
+
+export const Default = Template.bind({})
+
+Default.args = {
+}

--- a/packages/ui/stories/src/ButtonList.stories.tsx
+++ b/packages/ui/stories/src/ButtonList.stories.tsx
@@ -1,0 +1,31 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react'
+import * as React from 'react'
+import { Aether, Button, ButtonList } from '../../src'
+
+export default {
+	title: 'ButtonList',
+	component: ButtonList,
+	decorators: [
+		Story => (
+			<Aether style={{ alignItems: 'center', display: 'flex', flexDirection: 'row', flexWrap: 'wrap', gap: '1em', padding: '2em' }}>
+				<Story />
+			</Aether>
+		),
+	],
+} as ComponentMeta<typeof ButtonList>
+
+const Template: ComponentStory<typeof ButtonList> = args => <ButtonList {...args}>
+  <Button>Default</Button>
+  <Button intent="primary">Primary</Button>
+  <Button intent="secondary">Secondary</Button>
+  <Button intent="tertiary">Tertiary</Button>
+  <Button intent="success">Success</Button>
+  <Button intent="warn">Warn</Button>
+  <Button intent="danger">Danger</Button>
+  <Button intent="dark">Dark</Button>
+</ButtonList>
+
+export const Default = Template.bind({})
+
+Default.args = {
+}


### PR DESCRIPTION
Changes to `Button`:

1. More contrast on success and warning buttons
2. Focus ring on default synced with checkbox
3. Removed all colour when disabled
4. Label changed from normal na medium weight (better contrast when "seamless")
5. Border radius changed from 3px to 5px

Changes to `ButtonGroup` and `ButtonList`:

1. Apply size changes to child buttons without needing to pass prop to any of the Buttons
2. Add `size` & `orientation` props to `ButtonList` to unify with the `ButtonGroup`

### Checks
- [x] The changes and implementation strategy have been consulted with the maintainers.
- [x] The code passes all the checks (Run `pnpm run check`).
