### PR TITLE
Add Collapsible to Storybook

### DIFF
--- a/packages/ui/src/components/Collapsible.tsx
+++ b/packages/ui/src/components/Collapsible.tsx
@@ -8,6 +8,8 @@ export interface CollapsibleProps {
 	expanded: boolean
 	transition?: CollapsibleTransition
 	children?: ReactNode
+	onClose?: () => void
+	onOpen?: () => void
 	onTransitionEnd?: () => void
 }
 
@@ -18,9 +20,14 @@ export const Collapsible = memo((props: CollapsibleProps) => {
 	const [delayedExpanded, setDelayedExpanded] = useState(props.expanded)
 
 	const onTransitionEnd = () => {
+		if (!isTransitioning) {
+			return
+		}
+
 		setContentHeight('auto')
 		setIsTransitioning(false)
 		props.onTransitionEnd?.()
+		props.expanded ? props.onOpen?.() : props.onClose?.()
 	}
 
 	const updateContentHeight = () => {

--- a/packages/ui/stories/src/Collapsible.stories.tsx
+++ b/packages/ui/stories/src/Collapsible.stories.tsx
@@ -1,0 +1,42 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react'
+import * as React from 'react'
+import { Aether, Collapsible } from '../../src'
+
+
+export default {
+	title: 'Collapsible',
+	component: Collapsible,
+	decorators: [
+		Story => (
+			<Aether style={{ padding: '2em' }}>
+				<p>Content before…</p>
+				<Story />
+				<p>Content after…</p>
+			</Aether>
+		),
+	],
+} as ComponentMeta<typeof Collapsible>
+
+const Template: ComponentStory<typeof Collapsible> = args => <Collapsible {...args}>
+	<div style={{ background: 'white', borderRadius: '.5em', boxShadow: '0 .5em 5em rgba(0, 31, 91, .1)', overflow: 'auto', padding: '0 1em' }}>
+		<h4>Collapsible content</h4>
+		<p>
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer vel tincidunt lacus. Duis vestibulum, justo
+			vitae blandit tristique, dui tellus luctus nisi, vitae venenatis nunc ligula ac leo. Aenean non turpis a
+			velit ullamcorper ullamcorper.
+		</p>
+		<p>
+			Nam sed bibendum risus. Phasellus quis dui quis tortor pretium tempor ullamcorper in felis. Nunc quam dui,
+			tempor vel lacinia ut, pellentesque eget eros. Proin gravida auctor turpis sed pulvinar. Proin lacinia
+			imperdiet purus eu lobortis.
+		</p>
+	</div>
+</Collapsible>
+
+export const Simple = Template.bind({})
+Simple.args = {
+	expanded: true,
+	onTransitionEnd: () => console.log('Finished transition'),
+	onClose: () => console.log('Now it is closed'),
+	onOpen: () => console.log('Now it is open'),
+}


### PR DESCRIPTION
Adds `onClose` and `onOpen` props that could reduce open/close state tracking in parent components that use this component. There is also opportunity to deprecate and remove onTransitionEnd.

This PR fixes duplicate calls of the callbacks after transition.

### Checks
- [x] The changes and implementation strategy have been consulted with the maintainers.
- [x] The code passes all the checks (Run `pnpm run check`).
