### PR TITLE
Add Contember logo to Storybook

### DIFF
--- a/packages/ui/.storybook/preview.js
+++ b/packages/ui/.storybook/preview.js
@@ -1,3 +1,4 @@
+import { Aether } from '../src'
 import '../src/index.sass'
 import './global.sass'
 
@@ -9,4 +10,22 @@ export const parameters = {
       date: /Date$/,
     },
   },
+  docs: {
+    source: {
+      type: 'dynamic',
+      excludeDecorators: true,
+    },
+  },
 }
+
+export const decorators = [
+  (Story) => <Aether style={{
+    display: 'flex',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: '1em',
+    padding: '2em',
+  }}>
+    <Story />
+  </Aether>,
+]

--- a/packages/ui/src/components/ContemberLogo.tsx
+++ b/packages/ui/src/components/ContemberLogo.tsx
@@ -21,7 +21,7 @@ export const ContemberLogo = ({ logotype, size }: ContemberLogoProps) => {
 
 	switch (typeof size) {
 		case 'number':
-			fontSize = `${size}em`
+			fontSize = `${size >= 0 ? size : 1}em`
 			break
 		case 'string':
 			fontSize = `${logoSizes[size]}em`

--- a/packages/ui/stories/src/Box.stories.tsx
+++ b/packages/ui/stories/src/Box.stories.tsx
@@ -1,18 +1,11 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react'
 import * as React from 'react'
+import { Box } from '../../src'
 
-import { Aether, Box } from '../../src'
 
 export default {
 	title: 'Box',
 	component: Box,
-	decorators: [
-		Story => (
-			<Aether style={{ padding: '2em' }}>
-				<Story />
-			</Aether>
-		),
-	],
 } as ComponentMeta<typeof Box>
 
 const Template: ComponentStory<typeof Box> = args => <Box {...args} />

--- a/packages/ui/stories/src/Breadcrumbs.stories.tsx
+++ b/packages/ui/stories/src/Breadcrumbs.stories.tsx
@@ -1,17 +1,10 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react'
 import * as React from 'react'
-import { Aether, Breadcrumbs } from '../../src'
+import { Breadcrumbs } from '../../src'
 
 export default {
 	title: 'Breadcrumbs',
 	component: Breadcrumbs,
-	decorators: [
-		Story => (
-			<Aether style={{ display: 'flex', gap: '1em', justifyContent: 'flex-start', padding: '2em' }}>
-					<Story />
-			</Aether>
-		),
-	],
 } as ComponentMeta<typeof Breadcrumbs>
 
 const Template: ComponentStory<typeof Breadcrumbs> = args => <Breadcrumbs {...args} />

--- a/packages/ui/stories/src/Button.stories.tsx
+++ b/packages/ui/stories/src/Button.stories.tsx
@@ -1,18 +1,22 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react'
 import * as React from 'react'
-import { Aether, Button } from '../../src'
+import { Button } from '../../src'
 
 export default {
 	title: 'Button',
 	component: Button,
 	decorators: [
-		Story => (
-			<Aether style={{ alignItems: 'center', display: 'flex', flexDirection: 'row', flexWrap: 'wrap', gap: '1em', padding: '2em' }}>
-        <p style={{ flex: '100% 1 1' }}>This is a text with normal weight that is not clickable. And here's some <a href="#">link</a> that is clickable. Buttons should have enough clickable visual affordance event when seamless.</p>
-				<Story />
-			</Aether>
-		),
+		Story => <>
+      <p style={{ flex: '100% 1 1' }}>This is a text with normal weight that is not clickable. And here's some <a href="#">link</a> that is clickable. Buttons should have enough clickable visual affordance event when seamless.</p>
+      <Story />
+		</>,
 	],
+  argTypes: {
+    disabled: { defaultValue: false },
+    bland: { defaultValue: false },
+    isActive: { defaultValue: false },
+    isLoading: { defaultValue: false },
+  },
 } as ComponentMeta<typeof Button>
 
 const Template: ComponentStory<typeof Button> = args => <>

--- a/packages/ui/stories/src/ButtonGroup.stories.tsx
+++ b/packages/ui/stories/src/ButtonGroup.stories.tsx
@@ -1,17 +1,13 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react'
 import * as React from 'react'
-import { Aether, Button, ButtonGroup } from '../../src'
+import { Button, ButtonGroup } from '../../src'
 
 export default {
 	title: 'ButtonGroup',
 	component: ButtonGroup,
-	decorators: [
-		Story => (
-			<Aether style={{ alignItems: 'center', display: 'flex', flexDirection: 'row', flexWrap: 'wrap', gap: '1em', padding: '2em' }}>
-				<Story />
-			</Aether>
-		),
-	],
+  argTypes: {
+    isTopToolbar: { defaultValue: false },
+  },
 } as ComponentMeta<typeof ButtonGroup>
 
 const Template: ComponentStory<typeof ButtonGroup> = args => <ButtonGroup {...args}>

--- a/packages/ui/stories/src/ButtonList.stories.tsx
+++ b/packages/ui/stories/src/ButtonList.stories.tsx
@@ -1,17 +1,10 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react'
 import * as React from 'react'
-import { Aether, Button, ButtonList } from '../../src'
+import { Button, ButtonList } from '../../src'
 
 export default {
 	title: 'ButtonList',
 	component: ButtonList,
-	decorators: [
-		Story => (
-			<Aether style={{ alignItems: 'center', display: 'flex', flexDirection: 'row', flexWrap: 'wrap', gap: '1em', padding: '2em' }}>
-				<Story />
-			</Aether>
-		),
-	],
 } as ComponentMeta<typeof ButtonList>
 
 const Template: ComponentStory<typeof ButtonList> = args => <ButtonList {...args}>

--- a/packages/ui/stories/src/Collapsible.stories.tsx
+++ b/packages/ui/stories/src/Collapsible.stories.tsx
@@ -1,19 +1,17 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react'
 import * as React from 'react'
-import { Aether, Collapsible } from '../../src'
+import { Collapsible } from '../../src'
 
 
 export default {
 	title: 'Collapsible',
 	component: Collapsible,
 	decorators: [
-		Story => (
-			<Aether style={{ padding: '2em' }}>
-				<p>Content before…</p>
-				<Story />
-				<p>Content after…</p>
-			</Aether>
-		),
+		Story => <>
+			<p>Content before…</p>
+			<Story />
+			<p>Content after…</p>
+		</>,
 	],
 } as ComponentMeta<typeof Collapsible>
 

--- a/packages/ui/stories/src/ContemberLogo.stories.tsx
+++ b/packages/ui/stories/src/ContemberLogo.stories.tsx
@@ -1,0 +1,48 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react'
+import * as React from 'react'
+import { ContemberLogo } from '../../src'
+
+export default {
+	title: 'ContemberLogo',
+	parameters: {
+    docs: {
+      description: {
+        component: 'Contember logo component sized using ems.',
+      },
+    },
+  },
+	component: ContemberLogo,
+	argTypes: {
+		size: {
+			control: { type: 'range', min: 0, max: 10, step: 0.1 },
+		},
+		logotype: {
+			control: { type: 'boolean' },
+			defaultValue: true,
+		},
+	},
+} as ComponentMeta<typeof ContemberLogo>
+
+const Template: ComponentStory<typeof ContemberLogo> = args => <ContemberLogo {...args} />
+
+export const Numeric = Template.bind({})
+Numeric.args = {
+	size: 1,
+	logotype: true,
+}
+
+export const WithinText: ComponentStory<typeof ContemberLogo> = args => <p>
+	…and <ContemberLogo {...args} /> within the text
+</p>
+
+export const DefaultSize: ComponentStory<typeof ContemberLogo> = args => {
+	return <ContemberLogo {...args} size="default" />
+}
+
+export const SmallSize: ComponentStory<typeof ContemberLogo> = args => {
+	return <ContemberLogo {...args} size="small" />
+}
+
+export const LargeSize: ComponentStory<typeof ContemberLogo> = args => {
+	return <ContemberLogo {...args} size="large" />
+}

--- a/packages/ui/stories/src/Menu.stories.tsx
+++ b/packages/ui/stories/src/Menu.stories.tsx
@@ -1,17 +1,15 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react'
 import * as React from 'react'
-import { Aether, Menu, NavigationContext } from '../../src'
+import { Menu, NavigationContext } from '../../src'
 
 export default {
 	title: 'Menu',
 	component: Menu,
-	decorators: [
-		Story => (
-			<Aether style={{ padding: '2em' }}>
-				<Story />
-			</Aether>
-		),
-	],
+	argTypes: {
+		showCaret: {
+			defaultValue: true,
+		},
+	},
 } as ComponentMeta<typeof Menu>
 
 const Template: ComponentStory<typeof Menu> = args => (
@@ -22,15 +20,7 @@ const Template: ComponentStory<typeof Menu> = args => (
 			location.href = to
 		},
 	})}>
-		<Menu {...args} />
-	</NavigationContext.Provider>
-)
-
-export const Simple = Template.bind({})
-
-Simple.args = {
-	children: (
-		<>
+		<Menu {...args}>
 			<Menu.Item title="Front page" to="#active-page" />
 			<Menu.Item title="Pages">
 				<Menu.Item title="List all" to="#other-page" />
@@ -68,6 +58,9 @@ Simple.args = {
 				<Menu.Item title={<button type="button">Arbitrary JSX content</button>} />
 				<Menu.Item title="Last item" to="#active-page" />
 			</Menu.Item>
-		</>
-	),
-}
+		</Menu>
+	</NavigationContext.Provider>
+)
+
+export const Simple = Template.bind({})
+Simple.args = {}

--- a/packages/ui/stories/src/PersistControl.stories.tsx
+++ b/packages/ui/stories/src/PersistControl.stories.tsx
@@ -1,33 +1,32 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react'
 import * as React from 'react'
-import { Aether, PersistControl } from '../../src'
+import { PersistControl } from '../../src'
 
 export default {
 	title: 'PersistControl',
 	component: PersistControl,
 	decorators: [
-		Story => (<>
+		Story => <div style={{ display: 'flex', flex: 1, flexDirection: 'column' }}>
 			<p>Container set to align children flex-start:</p>
-			<Aether style={{ display: 'flex', gap: '1em', justifyContent: 'flex-start', padding: '2em' }}>
+			<div style={{ display: 'flex', gap: '1em', justifyContent: 'flex-start' }}>
 					<Story />
-			</Aether>
+			</div>
 
 			<p>Container set align children center:</p>
-			<Aether style={{ display: 'flex', gap: '1em', justifyContent: 'center', padding: '2em' }}>
+			<div style={{ display: 'flex', gap: '1em', justifyContent: 'center' }}>
 					<Story />
-			</Aether>
+			</div>
 
 			<p>Container set to align children flex-end:</p>
-			<Aether style={{ display: 'flex', gap: '1em', justifyContent: 'flex-end', padding: '2em' }}>
+			<div style={{ display: 'flex', gap: '1em', justifyContent: 'flex-end' }}>
 					<Story />
-			</Aether>
+			</div>
 
 			<p>Container set to stretch children:</p>
-			<Aether style={{ display: 'flex', flexDirection: 'column', gap: '1em', padding: '2em' }}>
+			<div style={{ display: 'flex', flexDirection: 'column', gap: '1em' }}>
 				<Story />
-			</Aether>
-			</>
-		),
+			</div>
+		</div>,
 	],
 } as ComponentMeta<typeof PersistControl>
 

--- a/packages/ui/stories/src/RadioGroup.stories.tsx
+++ b/packages/ui/stories/src/RadioGroup.stories.tsx
@@ -1,17 +1,14 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react'
 import * as React from 'react'
-import { Aether, RadioGroup } from '../../src'
+import { RadioGroup } from '../../src'
 
 export default {
 	title: 'RadioGroup',
 	component: RadioGroup,
-	decorators: [
-		Story => (
-			<Aether style={{ padding: '2em' }}>
-				<Story />
-			</Aether>
-		),
-	],
+	argTypes: {
+		isDisabled: { defaultValue: false },
+		isReadOnly: { defaultValue: false },
+	},
 } as ComponentMeta<typeof RadioGroup>
 
 const Template: ComponentStory<typeof RadioGroup> = args => <RadioGroup {...args} />

--- a/packages/ui/stories/src/Spinner.stories.tsx
+++ b/packages/ui/stories/src/Spinner.stories.tsx
@@ -1,31 +1,18 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react'
 import * as React from 'react'
-import { Aether, Spinner } from '../../src'
+import { Spinner } from '../../src'
 
 export default {
 	title: 'Spinner',
 	component: Spinner,
-	decorators: [
-		Story => (<>
-			<p>Default spinner:</p>
-			<Aether style={{ display: 'flex', gap: '1em', justifyContent: 'flex-start', padding: '2em' }}>
-					<Story />
-			</Aether>
-
-      <p>Spinner inheriting color:</p>
-			<Aether style={{ color: 'blue', display: 'flex', gap: '1em', justifyContent: 'flex-start', padding: '2em' }}>
-					<Story />
-			</Aether>
-
-			<p>Spinner inheriting color &amp; size:</p>
-			<Aether style={{ color: 'red', display: 'flex', fontSize: '4em', gap: '1em', justifyContent: 'flex-start', padding: '2em' }}>
-					<Story />
-			</Aether>
-			</>
-		),
-	],
 } as ComponentMeta<typeof Spinner>
 
-const Template: ComponentStory<typeof Spinner> = args => <Spinner />
+export const Defaut: ComponentStory<typeof Spinner> = () => <Spinner />
 
-export const Defaut = Template.bind({})
+export const InheritColor: ComponentStory<typeof Spinner> = () => <div style={{ color: 'blue' }}>
+	<Spinner />
+</div>
+
+export const InheritColorAndSize: ComponentStory<typeof Spinner> = () => <div style={{ color: 'red', fontSize: '4em' }}>
+	<Spinner />
+</div>


### PR DESCRIPTION
Add Contember logo stories:

- Start using global decorator
- Clip numeric value to be non-negative
- [Opt out of decorators when showing the source code](https://github.com/storybookjs/storybook/issues/12022#issuecomment-859540813)

Related changes:

- Refactor other components to use global decorator + add some boolean defaults

### Checks
- [x] The changes and implementation strategy have been consulted with the maintainers.
- [x] The code passes all the checks (Run `pnpm run check`).
