### PR TITLE
RadioButtonGroup

### DIFF
--- a/packages/ui/src/components/forms/RadioGroup/RadioButtonGroup.tsx
+++ b/packages/ui/src/components/forms/RadioGroup/RadioButtonGroup.tsx
@@ -1,0 +1,6 @@
+import type { RadioGroupProps } from './RadioGroup'
+import { RadioGroup } from './RadioGroup'
+
+export function RadioButtonGroup(props: Omit<RadioGroupProps, 'presentation'>) {
+	return <RadioGroup presentation="button" {...props} />
+}

--- a/packages/ui/src/components/forms/RadioGroup/RadioControl.tsx
+++ b/packages/ui/src/components/forms/RadioGroup/RadioControl.tsx
@@ -35,7 +35,7 @@ export const RadioControl = memo((props: RadioProps) => {
 		toEnumStateClass(validationState),
 		toStateClass('focused', isFocusVisible),
 		toStateClass('checked', isSelected),
-		toStateClass('indeterminate', state.selectedValue === null),
+		toStateClass('indeterminate', (state.selectedValue === null || state.selectedValue === '') && !isSelected),
 		toStateClass('disabled', isDisabled),
 		toStateClass('readonly', isReadOnly),
 		toStateClass('hovered', isHovered),

--- a/packages/ui/src/components/forms/RadioGroup/RadioControl.tsx
+++ b/packages/ui/src/components/forms/RadioGroup/RadioControl.tsx
@@ -13,10 +13,11 @@ interface RadioProps {
 	name?: string
 	validationState?: ValidationState
 	value: RadioOption['value']
+	centered?: boolean
 }
 
 export const RadioControl = memo((props: RadioProps) => {
-	const { children, description, validationState, value } = props
+	const { children, description, validationState, value, centered } = props
 
 	const prefix = useClassNamePrefix()
 	const ref = useRef<HTMLInputElement>(null)
@@ -38,6 +39,7 @@ export const RadioControl = memo((props: RadioProps) => {
 		toStateClass('disabled', isDisabled),
 		toStateClass('readonly', isReadOnly),
 		toStateClass('hovered', isHovered),
+		toStateClass('centered', centered),
 	)
 
 	return (

--- a/packages/ui/src/components/forms/RadioGroup/RadioGroup.tsx
+++ b/packages/ui/src/components/forms/RadioGroup/RadioGroup.tsx
@@ -5,6 +5,7 @@ import { useRadioGroupState } from 'react-stately'
 import { useClassNamePrefix } from '../../../auxiliary'
 import type { Size, ValidationState } from '../../../types'
 import { toEnumStateClass, toEnumViewClass } from '../../../utils'
+import { Icon } from '../../Icon'
 import { ErrorList, ErrorListProps } from '../ErrorList'
 import { RadioContext } from './RadioContext'
 import { RadioControl } from './RadioControl'
@@ -17,9 +18,11 @@ export interface RadioGroupProps extends ErrorListProps {
 	onChange: (newValue: string) => void
 	options: RadioOption[]
 	orientation?: 'horizontal' | 'vertical'
+	presentation?: 'radio' | 'button'
 	size?: Size
 	validationState?: ValidationState
 	value?: string
+	allowNull?: boolean
 }
 
 // TODO: Maybe extract later for reuse
@@ -35,7 +38,10 @@ function deriveAriaValidationState(validationState?: ValidationState): 'valid' |
 }
 
 export const RadioGroup = memo((props: RadioGroupProps) => {
-	const { errors, name, options, orientation, size, validationState } = props
+	const { errors, name, options, size, validationState, allowNull } = props
+
+	const presentation = props.presentation ?? 'radio'
+	const orientation = props.orientation ?? (presentation === 'button' ? 'horizontal' : 'vertical')
 
 	const prefix = useClassNamePrefix()
 
@@ -47,11 +53,15 @@ export const RadioGroup = memo((props: RadioGroupProps) => {
 	const state = useRadioGroupState(ariaRadioGroupProps)
 	const { radioGroupProps } = useRadioGroup(ariaRadioGroupProps, state)
 
+	const hasSelectedSomething = !(state.selectedValue === null || typeof state.selectedValue === 'undefined')
+
 	const classList = classNames(
 		`${prefix}radio-group`,
 		toEnumViewClass(size),
 		toEnumStateClass(validationState),
-		toEnumViewClass(orientation ?? 'vertical'),
+		toEnumViewClass(orientation),
+		toEnumViewClass(presentation),
+		toEnumViewClass(allowNull ? 'allowNull' : 'denyNull'),
 	)
 
 	return (
@@ -69,6 +79,17 @@ export const RadioGroup = memo((props: RadioGroupProps) => {
 							{label}
 						</RadioControl>
 					))}
+					{allowNull && hasSelectedSomething && (
+						<RadioControl
+							name={name}
+							value={null as unknown as string}
+							validationState={validationState}
+							description={null}
+							centered
+						>
+							<Icon blueprintIcon="cross" />
+						</RadioControl>
+					)}
 				</RadioContext.Provider>
 			</div>
 			{!!errors && (

--- a/packages/ui/src/components/forms/RadioGroup/RadioGroup.tsx
+++ b/packages/ui/src/components/forms/RadioGroup/RadioGroup.tsx
@@ -56,22 +56,26 @@ export const RadioGroup = memo((props: RadioGroupProps) => {
 
 	return (
 		<div className={classList} {...radioGroupProps}>
-			<RadioContext.Provider value={state}>
-				{options.map(({ value, label, labelDescription }: RadioOption) => (
-					<RadioControl
-						key={value}
-						name={name}
-						value={value}
-						validationState={validationState}
-						description={labelDescription}
-					>
-						{label}
-					</RadioControl>
-				))}
-			</RadioContext.Provider>
+			<div className={`${prefix}radio-group-options`}>
+				<RadioContext.Provider value={state}>
+					{options.map(({ value, label, labelDescription }: RadioOption) => (
+						<RadioControl
+							key={value}
+							name={name}
+							value={value}
+							validationState={validationState}
+							description={labelDescription}
+						>
+							{label}
+						</RadioControl>
+					))}
+				</RadioContext.Provider>
+			</div>
 			{!!errors && (
-				<div className={`${prefix}checkbox-errors`}>
-					<ErrorList errors={errors} size={size} />
+				<div className={`${prefix}radio-group-error`}>
+					<div className={`${prefix}checkbox-errors`}>
+						<ErrorList errors={errors} size={size} />
+					</div>
 				</div>
 			)}
 		</div>

--- a/packages/ui/src/components/forms/RadioGroup/index.ts
+++ b/packages/ui/src/components/forms/RadioGroup/index.ts
@@ -1,2 +1,3 @@
 export * from './RadioGroup'
+export * from './RadioButtonGroup'
 export * from './types'

--- a/packages/ui/src/styles/components/radio.sass
+++ b/packages/ui/src/styles/components/radio.sass
@@ -14,10 +14,17 @@
 		display: flex
 		flex-direction: column
 		gap: $gap-between
-		&.view-horizontal
+
+		&-options
+			display: flex
+			flex-direction: column
+			gap: $gap-between
+
+		&.view-horizontal &-options
 			flex-direction: row
 			flex-wrap: wrap
 			gap: $gap-between
+
 		&.view-small
 			font-size: $cui-control-small-font-size
 		&.view-large

--- a/packages/ui/src/styles/components/radio.sass
+++ b/packages/ui/src/styles/components/radio.sass
@@ -3,14 +3,19 @@
 @import '../common'
 
 .#{$cui-conf-globalPrefix}radio
+	$root: #{&}
 	$size: 1.2em
 	$gap: .35em
 	$radio-knob-percent: 60%
 	$t-background: .08s
 	$gap-between: .75em
+	$button-radius: .3em
 
 	&-group
 		--radio-color: #{$cui-control-view-default-border-color}
+		--radio-checked-color: #{$cui-control-view-default-distinction-color}
+		--radio-invalid-color: #{$cui-control-validation-invalid-color}
+		--radio-state-color: #{$cui-control-view-default-border-color}
 		display: flex
 		flex-direction: column
 		gap: $gap-between
@@ -18,12 +23,13 @@
 		&-options
 			display: flex
 			flex-direction: column
+
+		&.view-radio &-options
 			gap: $gap-between
 
 		&.view-horizontal &-options
 			flex-direction: row
 			flex-wrap: wrap
-			gap: $gap-between
 
 		&.view-small
 			font-size: $cui-control-small-font-size
@@ -34,12 +40,12 @@
 		align-items: flex-start
 		display: flex
 		flex-direction: row
-		&.is-checked
-			--radio-color: #{$cui-control-view-default-distinction-color}
+
+		&.is-checked,
 		&.is-checked.is-readonly
-			--radio-color: #{$cui-control-view-default-border-color}
+			--radio-state-color: var(--radio-checked-color)
 		&.is-invalid
-			--radio-color: #{$cui-control-validation-invalid-color}
+			--radio-state-color: var(--radio-invalid-color)
 		&.is-disabled
 			cursor: not-allowed
 			opacity: 0.5
@@ -49,7 +55,7 @@
 		min-width: $size
 		height: $size
 		border-radius: 50%
-		border: $cui-control-border-width solid var(--radio-color) // TODO: A11Y issue: Too light grey colour
+		border: $cui-control-border-width solid var(--radio-state-color) // TODO: A11Y issue: Too light grey colour
 		margin-inline-end: $gap
 		position: relative
 		transition-property: background-color, border-color, box-shadow
@@ -94,10 +100,58 @@
 			line-height: $cui-base-lineHeight
 
 	&-option.is-checked &-control::after
-		background-color: var(--radio-color)
+		background-color: var(--radio-state-color)
 	&-option.is-focused &-control::before
 		box-shadow: 0 0 0 .2em rgba($cui-control-view-default-distinction-color, $cui-control-focus-opacity)
 	&-option.is-focused:not(.is-checked) &-control::before
 		border-color: lighten($cui-control-view-default-distinction-color, 10)
 	&-option.is-checked &-control::after
 		transform: scale(1)
+
+	&-group.view-button &-option
+		position: relative
+		border: $cui-control-border-width solid var(--radio-state-color) // TODO: A11Y issue: Too light grey colour
+		padding: $gap $gap-between
+
+		&.is-checked #{$root}-label-main
+			color: var(--radio-checked-color)
+
+		&.is-checked
+			border-color: var(--radio-checked-color)
+
+	&-group.view-button &-option &-control
+		display: none
+
+	&-group.view-button.view-horizontal &-option:not(:first-child)
+		margin-left: -$cui-control-border-width
+
+	&-group.view-button.view-vertical &-option:not(:first-child)
+		margin-top: -$cui-control-border-width
+
+	&-group.view-button &-option.is-checked
+		z-index: 1
+
+	&-group.view-button.view-horizontal &-option:first-child
+		border-top-left-radius: $button-radius
+		border-bottom-left-radius: $button-radius
+
+	&-group.view-button.view-horizontal &-option:last-child
+		border-top-right-radius: $button-radius
+		border-bottom-right-radius: $button-radius
+
+	&-group.view-button.view-vertical &-option:first-child
+		border-top-left-radius: $button-radius
+		border-top-right-radius: $button-radius
+
+	&-group.view-button.view-vertical &-option:last-child
+		border-bottom-left-radius: $button-radius
+		border-bottom-right-radius: $button-radius
+
+	&-group.view-button &-option.is-centered &-label
+		margin: auto
+
+		&-main
+			display: flex
+			justify-content: center
+			align-items: center
+			line-height: 1

--- a/packages/ui/stories/src/RadioButtonGroup.stories.tsx
+++ b/packages/ui/stories/src/RadioButtonGroup.stories.tsx
@@ -1,0 +1,115 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react'
+import * as React from 'react'
+import { RadioButtonGroup } from '../../src'
+
+export default {
+	title: 'RadioButtonGroup',
+	component: RadioButtonGroup,
+	argTypes: {
+		isDisabled: { defaultValue: false },
+		isReadOnly: { defaultValue: false },
+		allowNull: { defaultValue: true },
+	},
+} as ComponentMeta<typeof RadioButtonGroup>
+
+const Template: ComponentStory<typeof RadioButtonGroup> = args => <RadioButtonGroup {...args} />
+
+export const Simple = Template.bind({})
+
+Simple.args = {
+	name: 'foo',
+	options: [
+		{
+			value: 'alpha',
+			label: 'Alpha',
+		},
+		{
+			value: 'beta',
+			label: 'Beta',
+		},
+	],
+	size: 'default',
+	onChange: value => console.log(value),
+}
+
+export const WithDescriptions = Template.bind({})
+
+WithDescriptions.args = {
+	name: 'foo',
+	options: [
+		{
+			value: 'alpha',
+			label: 'Alpha',
+			labelDescription: 'First letter in Greek alphabet',
+		},
+		{
+			value: 'beta',
+			label: 'Beta',
+			labelDescription: 'Second letter in Greek alphabet',
+		},
+	],
+	size: 'default',
+	onChange: value => console.log(value),
+}
+
+export const LongLabels = Template.bind({})
+
+LongLabels.args = {
+	name: 'foo',
+	orientation: 'vertical',
+	options: [
+		{
+			value: 'alpha',
+			label:
+				'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua',
+		},
+		{
+			value: 'beta',
+			label:
+				'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo',
+		},
+	],
+	size: 'default',
+	onChange: value => console.log(value),
+}
+
+export const Preselected = Template.bind({})
+
+Preselected.args = {
+	name: 'foo',
+	allowNull: false,
+	options: [
+		{
+			value: 'alpha',
+			label: 'Alpha',
+		},
+		{
+			value: 'beta',
+			label: 'Beta',
+		},
+	],
+	size: 'default',
+	value: 'beta',
+	onChange: value => console.log(value),
+	// errors: [{ message: 'Wrong' }],
+}
+
+export const WithErrors = Template.bind({})
+
+WithErrors.args = {
+	name: 'foo',
+	options: [
+		{
+			value: 'alpha',
+			label: 'Alpha',
+		},
+		{
+			value: 'beta',
+			label: 'Beta',
+		},
+	],
+	size: 'default',
+	onChange: value => console.log(value),
+	errors: [{ message: 'Select at least one' }],
+	validationState: 'invalid',
+}


### PR DESCRIPTION
# Primary objective: Extend `RadioGroup` to support presentation as `ButtonGroup`.


https://user-images.githubusercontent.com/316435/132020416-6f2fee37-43a7-4977-9fa3-4cdea380ee0e.mov

# But Also

## Error note on `RadioGroup` with `orientation=horizontal`

...shall be under the control instead of at the end

<img width="371" alt="Screenshot 2021-09-03 at 14 53 38" src="https://user-images.githubusercontent.com/316435/132020644-4a30418a-6c99-40ef-82a0-ba46ea14055d.png">


## Remove ugly gradients from buttons

### Old

<img width="529" alt="Screenshot 2021-09-03 at 16 24 40" src="https://user-images.githubusercontent.com/316435/132021319-5070df7c-f1ce-4d69-9786-5035ec53ca51.png">


### Now

Still ugly, but less.

<img width="512" alt="Screenshot 2021-09-03 at 14 53 11" src="https://user-images.githubusercontent.com/316435/132020490-03540769-85b0-440d-ab65-93ab97440422.png">
