### PR TITLE
Fix breakpoints

### DIFF
--- a/packages/admin/src/styles/parts/navbar.sass
+++ b/packages/admin/src/styles/parts/navbar.sass
@@ -27,7 +27,7 @@
 		margin-right: $spacing-normal
 		color: inherit
 
-		+media($break768M)
+		@media (max-width: $max-width-break-point-tablet)
 			display: none
 
 	&-link

--- a/packages/admin/src/styles/parts/sideDimensions.sass
+++ b/packages/admin/src/styles/parts/sideDimensions.sass
@@ -32,7 +32,7 @@
 			text-transform: uppercase
 			top: 0
 
-	@media (min-width: $break768)
+	@media (min-width: $min-width-break-point-tablet)
 		&-dimensions
 			gap: $cui-gap * 6
 			&-in

--- a/packages/ui/src/components/Containers/Section/section.sass
+++ b/packages/ui/src/components/Containers/Section/section.sass
@@ -16,5 +16,5 @@
   &:last-child
     margin-bottom: calc(-1 * var(--section-padding-vertical, 0))
 
-  @media (min-width: $break1200)
+  @media (min-width: $min-width-break-point-desktop)
     scroll-margin-top: 0

--- a/packages/ui/src/components/Layout/LayoutChrome.sass
+++ b/packages/ui/src/components/Layout/LayoutChrome.sass
@@ -46,7 +46,7 @@
 			flex-wrap: nowrap
 			gap: $cui-gap * 2
 
-	@media (min-width: $break768)
+	@media (min-width: $min-width-break-point-tablet)
 		flex-direction: row
 
 		&-bar
@@ -56,7 +56,7 @@
 		&-navigation-button
 			display: none
 
-	@media (max-width: $break768M)
+	@media (max-width: $max-width-break-point-tablet)
 		&-bar
 			height: 100vh
 		&.view-collapsed &-bar

--- a/packages/ui/src/components/Layout/LayoutPage.sass
+++ b/packages/ui/src/components/Layout/LayoutPage.sass
@@ -11,7 +11,7 @@
 		flex-direction: column
 		padding: var(--section-padding-vertical) var(--section-padding-horizontal)
 
-		@media (min-width: $break768)
+		@media (min-width: $min-width-break-point-tablet)
 			--section-padding-horizontal: #{($cui-gap * 8)}
 			--section-padding-vertical: #{($cui-gap * 8)}
 			--section-gap: #{$cui-gap * 8}
@@ -45,11 +45,11 @@
 		&-title
 			margin: 0
 
-	@media (min-width: $break768)
+	@media (min-width: $min-width-break-point-tablet)
 		&-aside
 			padding: ($cui-gap * 8) ($cui-gap * 8)
 
-@media (min-width: $break1200)
+@media (min-width: $min-width-break-point-desktop)
 	html
 		height: 100vh
 		margin: 0

--- a/packages/ui/src/components/SectionTabs/SectionTabs.sass
+++ b/packages/ui/src/components/SectionTabs/SectionTabs.sass
@@ -7,9 +7,9 @@
 
   padding: 0 ($cui-gap * 2)
 
-  @media (min-width: $break768)
+  @media (min-width: $min-width-break-point-tablet)
     padding: 0 ($cui-gap * 6)
 
   .is-meta
-    @media (min-width: $break1200)
+    @media (min-width: $min-width-break-point-desktop)
       display: none

--- a/packages/ui/src/styles/_variables.scss
+++ b/packages/ui/src/styles/_variables.scss
@@ -5,6 +5,11 @@
 $extra-optical-size-rounded-rectangle: 0.2146;
 $extra-optical-size-circle: 0.1284;
 
+$min-width-break-point-tablet: 768px;
+$max-width-break-point-tablet: 767.98px;
+$min-width-break-point-desktop: 1200px;
+$max-width-break-point-desktop: 1199.98px;
+
 // "CUI" stands for Contember UI
 
 // Core configurations

--- a/packages/ui/src/styles/components/titleBar.sass
+++ b/packages/ui/src/styles/components/titleBar.sass
@@ -31,7 +31,7 @@
 		flex: 0 0 auto
 		margin-left: auto
 
-	@media (min-width: $break768)
+	@media (min-width: $min-width-break-point-tablet)
 		--padding-horizontal: #{$cui-gap * 8}
 
 		padding: ($cui-gap * 4) ($cui-gap * 8)


### PR DESCRIPTION
Closes #79

Custom properties are not possible to be used in `@media`

### Checks
- [x] The changes and implementation strategy have been consulted with the maintainers.
- [x] The code passes all the checks (Run `pnpm run check`).
