### PR TITLE
Pr/sidebar size

### DIFF
--- a/packages/admin/src/styles/parts/sideDimensions.sass
+++ b/packages/admin/src/styles/parts/sideDimensions.sass
@@ -33,24 +33,12 @@
 			top: 1px
 			z-index: 1
 
-	@media (min-width: $breakpoint-min-medium)
-		&-dimensions
-			gap: var(--cui-layout-section-gap)
-			&-dimension
-				min-width: 20em
-			&-in
-				flex-direction: row
+	.#{$cui-conf-globalPrefix}layout-page-content &
+		@media (min-width: $breakpoint-min-medium)
+			&-dimensions
 				gap: var(--cui-layout-section-gap)
-			&-in:not(:first-child) &-dimensionValue
-				display: none
-	@media (min-width: $breakpoint-min-large)
-		&-dimensions
-			&-dimension
-				min-width: 25em
-	@media (min-width: $breakpoint-min-xlarge)
-		&-dimensions
-			&-dimension
-				min-width: 28.5em
-
-	[class*="-ValueContainer2"] &-dimensions-dimension
-		min-width: unset
+				&-in
+					flex-direction: row
+					gap: var(--cui-layout-section-gap)
+				&-in:not(:first-child) &-dimensionValue
+					display: none

--- a/packages/ui/src/components/Forms/FieldContainer/FieldContainer.sass
+++ b/packages/ui/src/components/Forms/FieldContainer/FieldContainer.sass
@@ -1,12 +1,15 @@
 @use 'sass:math'
 
 .#{$cui-conf-globalPrefix}field-container
+	align-self: stretch
+	column-gap: calc(2 * var(--cui-gap-horizontal))
 	display: flex
 	flex-direction: column
 	font-size: var(--cui-control-font-size)
-	column-gap: calc(2 * var(--cui-gap-horizontal))
 	row-gap: calc(2 * var(--cui-gap-vertical))
-	width: 100%
+
+	.#{$cui-conf-globalPrefix}layout-page-content-wrap &
+		min-width: var(--cui-field-container-min-width)
 
 	&.view-small
 		font-size: var(--cui-control-font-size--small)

--- a/packages/ui/src/components/Layout/LayoutPage.sass
+++ b/packages/ui/src/components/Layout/LayoutPage.sass
@@ -16,16 +16,17 @@
 		position: relative
 		z-index: 1
 	&-content
-		padding-top: var(--cui-layout-page-padding-top)
-		padding-left: var(--cui-layout-page-padding-left)
-		padding-right: var(--cui-layout-page-padding-right)
-		padding-bottom: var(--cui-layout-page-padding-bottom)
 		display: flex
 		flex-direction: row
 		flex: 1
 		// TODO: Any non 'visible' value causes floating menu not to stick
 		overflow-x: auto
 		overflow-y: visible
+		padding-top: var(--cui-layout-page-padding-top)
+		padding-left: var(--cui-layout-page-padding-left)
+		padding-right: var(--cui-layout-page-padding-right)
+		padding-bottom: var(--cui-layout-page-padding-bottom)
+		transition: border-color var(--cui-transition-duration)
 		&:not(:last-child)
 			padding-right: var(--cui-layout-section-padding-right)
 	&-content-container
@@ -40,7 +41,6 @@
 		display: flex
 		flex-direction: column
 		margin-top: calc(-1 * var(--cui-control-border-width))
-		// TODO: Any non 'visible' value causes floating menu not to stick
 		overflow: visible
 		&-title
 			margin: 0
@@ -63,12 +63,16 @@
 			flex-direction: row
 			overflow: hidden
 		&-content
+			border-right: 1px solid transparent
 			overflow-y: auto
+			&.is-overflowing
+				border-right-color: var(--cui-color--lower)
 		&-aside
 			background-color: unset
 			border-top: unset
 			margin-top: unset
 			max-width: 50%
+			// TODO: Any non 'visible' value causes floating menu not to stick
 			overflow-y: auto
 			position: sticky
 			top: 0

--- a/packages/ui/src/components/Layout/LayoutPage.sass
+++ b/packages/ui/src/components/Layout/LayoutPage.sass
@@ -19,7 +19,6 @@
 		display: flex
 		flex-direction: row
 		flex: 1
-		// TODO: Any non 'visible' value causes floating menu not to stick
 		overflow-x: auto
 		overflow-y: visible
 		padding-top: var(--cui-layout-page-padding-top)
@@ -72,7 +71,6 @@
 			border-top: unset
 			margin-top: unset
 			max-width: 50%
-			// TODO: Any non 'visible' value causes floating menu not to stick
 			overflow-y: auto
 			position: sticky
 			top: 0

--- a/packages/ui/src/components/Layout/LayoutPage.sass
+++ b/packages/ui/src/components/Layout/LayoutPage.sass
@@ -22,7 +22,8 @@
 		padding-bottom: var(--cui-layout-page-padding-bottom)
 		display: flex
 		flex-direction: row
-		flex-grow: 1
+		flex: 1
+		// TODO: Any non 'visible' value causes floating menu not to stick
 		overflow-x: auto
 		overflow-y: visible
 		&:not(:last-child)
@@ -36,27 +37,20 @@
 		background-color: var(--cui-background-color--above)
 		border-radius: unset
 		border-top: 1px solid var(--cui-color--lower)
-		margin-top: calc(-1 * var(--cui-control-border-width))
 		display: flex
 		flex-direction: column
+		margin-top: calc(-1 * var(--cui-control-border-width))
 		// TODO: Any non 'visible' value causes floating menu not to stick
-		overflow-x: auto
-		overflow-y: visible
-		padding-bottom: var(--cui-layout-section-padding-bottom)
-		padding-left: var(--cui-layout-page-padding-left)
-		padding-right: var(--cui-layout-page-padding-right)
-		padding-top: var(--cui-layout-section-padding-top)
-		width: auto
+		overflow: visible
 		&-title
 			margin: 0
-	@media (min-width: $breakpoint-min-medium)
-		// TODO: Fix layout issue: https://github.com/contember/private-issues/issues/21
-		[class$="container"] > [class$="control"]
-			min-width: 20em
+		&-content
+			padding-bottom: var(--cui-layout-section-padding-bottom)
+			padding-left: var(--cui-layout-page-padding-left)
+			padding-right: var(--cui-layout-page-padding-right)
+			padding-top: var(--cui-layout-section-padding-top)
+
 	@media (min-width: $breakpoint-min-large)
-		// TODO: Fix layout issue: https://github.com/contember/private-issues/issues/21
-		[class$="container"] > [class$="control"]
-			min-width: 25em
 		&-content-container
 			flex-grow: unset
 			margin-left: auto
@@ -73,18 +67,14 @@
 		&-aside
 			background-color: unset
 			border-top: unset
-			flex-shrink: 0
 			margin-top: unset
 			max-width: 50%
 			overflow-y: auto
-			padding-left: var(--cui-layout-section-padding-left)
 			position: sticky
 			top: 0
+			&-content
+				padding-left: var(--cui-layout-section-padding-left)
 
-			// React-select override
-			// TODO: Fix layout issue: https://github.com/contember/private-issues/issues/21
-			[class$="container"] > [class$="control"]
-				min-width: 28.5em
 
 @media (min-width: $breakpoint-min-xlarge)
 	html

--- a/packages/ui/src/components/Layout/LayoutPage.tsx
+++ b/packages/ui/src/components/Layout/LayoutPage.tsx
@@ -14,7 +14,12 @@ export const PageLayoutContent = ({ children }: { children: ReactNode }) => {
 	const contentRef = useRef<HTMLDivElement>(null)
 
 	useEffect(() => {
+		if (!contentRef.current) {
+			return
+		}
+
 		const contentRefCopy = contentRef.current
+
 		const listener = () => {
 			const offsetWidth = Math.floor(contentRefCopy?.offsetWidth ?? 0)
 			const scrollWidth = Math.floor(contentRefCopy?.scrollWidth ?? 0)
@@ -23,9 +28,7 @@ export const PageLayoutContent = ({ children }: { children: ReactNode }) => {
 
 			const nextIsOverflowing = offsetWidth < scrollWidth && scrollRight > 1
 
-			if (isOverflowing !== nextIsOverflowing) {
-				setIsOverflowing(nextIsOverflowing)
-			}
+			setIsOverflowing(nextIsOverflowing)
 		}
 
 		listener()
@@ -34,7 +37,7 @@ export const PageLayoutContent = ({ children }: { children: ReactNode }) => {
 		return () => {
 			contentRefCopy?.removeEventListener('scroll', listener)
 		}
-	}, [contentRef, isOverflowing])
+	}, [])
 
 	return <div
 		ref={contentRef}

--- a/packages/ui/src/components/Layout/LayoutPage.tsx
+++ b/packages/ui/src/components/Layout/LayoutPage.tsx
@@ -21,9 +21,9 @@ export const PageLayoutContent = ({ children }: { children: ReactNode }) => {
 		const contentRefCopy = contentRef.current
 
 		const listener = () => {
-			const offsetWidth = Math.floor(contentRefCopy?.offsetWidth ?? 0)
-			const scrollWidth = Math.floor(contentRefCopy?.scrollWidth ?? 0)
-			const scrollLeft = Math.floor(contentRefCopy?.scrollLeft ?? 0)
+			const offsetWidth = Math.floor(contentRefCopy.offsetWidth ?? 0)
+			const scrollWidth = Math.floor(contentRefCopy.scrollWidth ?? 0)
+			const scrollLeft = Math.floor(contentRefCopy.scrollLeft ?? 0)
 			const scrollRight = scrollWidth - offsetWidth - scrollLeft
 
 			const nextIsOverflowing = offsetWidth < scrollWidth && scrollRight > 1
@@ -32,10 +32,10 @@ export const PageLayoutContent = ({ children }: { children: ReactNode }) => {
 		}
 
 		listener()
-		contentRefCopy?.addEventListener('scroll', listener, { passive: true })
+		contentRefCopy.addEventListener('scroll', listener, { passive: true })
 
 		return () => {
-			contentRefCopy?.removeEventListener('scroll', listener)
+			contentRefCopy.removeEventListener('scroll', listener)
 		}
 	}, [])
 

--- a/packages/ui/src/components/Layout/LayoutPage.tsx
+++ b/packages/ui/src/components/Layout/LayoutPage.tsx
@@ -40,7 +40,7 @@ function isElementFixed (element: HTMLDivElement) {
 }
 
 const Aside = memo(({ children }: { children: ReactNode }) => {
-	const prefix = useClassNamePrefix()
+	const componentClassName = `${useClassNamePrefix()}layout-page-aside`
 	const [registerTab, unregisterTab] = useSectionTabsRegistration()
 	const element = useRef<HTMLDivElement>(null)
 
@@ -68,8 +68,8 @@ const Aside = memo(({ children }: { children: ReactNode }) => {
 		}
 	})
 
-	return <div ref={element} id={metaTab.id} className={`${prefix}layout-page-aside`}>
-		<Stack gap="large" direction="vertical">
+	return <div ref={element} id={metaTab.id} className={componentClassName}>
+		<Stack gap="large" direction="vertical" className={`${componentClassName}-content`}>
 			{children}
 		</Stack>
 	</div>

--- a/packages/ui/src/styles/_customProperties.sass
+++ b/packages/ui/src/styles/_customProperties.sass
@@ -32,6 +32,8 @@
 	--cui-edge-offset-left: var(--cui-edge-offset-horizontal)
 	--cui-edge-offset-right: var(--cui-edge-offset-horizontal)
 
+	--cui-field-container-min-width: 100%
+
 	@media (min-width: $breakpoint-min-small)
 		--cui-gap-horizontal: #{em(5px)}
 		--cui-padding-horizontal: calc(var(--cui-gap-horizontal) * 4)
@@ -39,9 +41,11 @@
 	@media (min-width: $breakpoint-min-medium)
 		--cui-padding-horizontal: calc(var(--cui-gap-horizontal) * 5)
 		--cui-edge-offset-horizontal: calc(var(--cui-gap-horizontal) * 2)
+		--cui-field-container-min-width: 20em
 	@media (min-width: $breakpoint-min-large)
 		--cui-gap-horizontal: #{em(6px)}
 		--cui-edge-offset-horizontal: calc(var(--cui-gap-horizontal) * 3)
+		--cui-field-container-min-width: 25em
 	@media (min-width: $breakpoint-min-xlarge)
 		--cui-padding-horizontal: calc(var(--cui-gap-horizontal) * 6)
 		--cui-edge-offset-horizontal: calc(var(--cui-gap-horizontal) * 4)


### PR DESCRIPTION
Disables row layout od side dimensions in the sidebar and removes select width overrides.

New: Adds page body divider when content overflows.

Closes: https://github.com/contember/private-issues/issues/21
Closes: https://github.com/contember/private-issues/issues/1

### Checks
- [x] The changes and implementation strategy have been consulted with the maintainers.
- [x] The code passes all the checks (Run `pnpm run check`).
