### PR TITLE
Fix table popups

### DIFF
--- a/packages/ui/src/components/Box/Box.sass
+++ b/packages/ui/src/components/Box/Box.sass
@@ -36,6 +36,10 @@
 		border-radius: unset
 	&.view-no-padding
 		--cui-box-content-padding: 0
+		--cui-box-content-padding-left: 0
+		--cui-box-content-padding-right: 0
+		--cui-box-content-padding-top: 0
+		--cui-box-content-padding-bottom: 0
 
 	&-header,
 	&-body

--- a/packages/ui/src/components/Box/Box.tsx
+++ b/packages/ui/src/components/Box/Box.tsx
@@ -21,7 +21,7 @@ export interface BoxProps extends BoxOwnProps, Omit<NativeProps<HTMLDivElement>,
 
 export const Box = memo(
 	forwardRef<HTMLDivElement, BoxProps>(
-		({ actions, className, distinction, children, gap, heading, intent, isActive, padding = 'default', ...divProps }: BoxProps, ref) => {
+		({ actions, className, distinction, children, gap, heading, intent, isActive, padding, ...divProps }: BoxProps, ref) => {
 			const componentClassName = `${useClassNamePrefix()}box`
 
 			return (

--- a/packages/ui/src/components/Box/Box.tsx
+++ b/packages/ui/src/components/Box/Box.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames'
 import { forwardRef, memo, ReactNode } from 'react'
 import { useClassNamePrefix } from '../../auxiliary'
-import type { BoxDistinction, Intent, NativeProps, Size } from '../../types'
+import type { BoxDistinction, Default, Intent, NativeProps, Size } from '../../types'
 import { toEnumViewClass, toStateClass, toThemeClass } from '../../utils'
 import { Stack } from '../Stack'
 import { Label } from '../Typography/Label'
@@ -14,13 +14,14 @@ export interface BoxOwnProps {
 	heading?: ReactNode
 	isActive?: boolean
 	intent?: Intent
+	padding?: Default | 'no-padding'
 }
 
 export interface BoxProps extends BoxOwnProps, Omit<NativeProps<HTMLDivElement>, 'children'> {}
 
 export const Box = memo(
 	forwardRef<HTMLDivElement, BoxProps>(
-		({ actions, className, distinction, children, gap, heading, intent, isActive, ...divProps }: BoxProps, ref) => {
+		({ actions, className, distinction, children, gap, heading, intent, isActive, padding = 'default', ...divProps }: BoxProps, ref) => {
 			const componentClassName = `${useClassNamePrefix()}box`
 
 			return (
@@ -31,6 +32,7 @@ export const Box = memo(
 						toStateClass('active', isActive),
 						toEnumViewClass(distinction),
 						toThemeClass(intent),
+						toEnumViewClass(padding),
 						className,
 					)}
 					ref={ref}

--- a/packages/ui/src/components/Table/Table.tsx
+++ b/packages/ui/src/components/Table/Table.tsx
@@ -41,8 +41,8 @@ export const Table = memo(({ /*useTableElement = true, */ bare, ...props }: Tabl
 
 	return (
 		<UseTableElementContext.Provider value={/*useTableElement*/ true}>
-			<FieldContainer label={!bare && props.heading}>
-				<Box className="view-no-padding">
+			<FieldContainer label={!bare && props.heading} useLabelElement={false}>
+				<Box padding="no-padding">
 					{table}
 				</Box>
 			</FieldContainer>


### PR DESCRIPTION
To add labels outside of the box `FieldContainer` is being used.  Problem is caused by the use of `<label>` HTML component, which should only be used with focusable inputs.

Also fixes no-padding regression styles and introduces interface prop to pair with class styles.

Closes https://github.com/contember/private-issues/issues/12

### Checks
- [x] The changes and implementation strategy have been consulted with the maintainers.
- [x] The code passes all the checks (Run `pnpm run check`).
