### PR TITLE
Hotfix page conditions

### DIFF
--- a/packages/admin/src/components/pageRouting/Pages.tsx
+++ b/packages/admin/src/components/pageRouting/Pages.tsx
@@ -121,7 +121,7 @@ export const Pages = ({ children, layout }: PagesProps) => {
 
 
 function isPageProvider(it: any): it is PageProvider<any> {
-	return typeof it === 'object' && it !== null && typeof it.getPageName === 'function'
+	return typeof it.getPageName === 'function'
 }
 
 function isPageProviderElement(el: ReactNode): el is PageProviderElement {


### PR DESCRIPTION
`it` is not an `object`, it's a `function`. Truncating to sufficient condition.

Closes #

### Checks
- [x] The changes and implementation strategy have been consulted with the maintainers.
- [x] The code passes all the checks (Run `pnpm run check`).
