### PR TITLE
Fix vertical aligment of date time inputs

### DIFF
--- a/packages/ui/src/styles/components/input.sass
+++ b/packages/ui/src/styles/components/input.sass
@@ -6,6 +6,7 @@
 
 	&:is([type="date"], [type="time"], [type="datetime-local"], [type="month"], [type="week"])
 		-webkit-appearance: textfield
+		display: inline-flex
 	&::-webkit-date-and-time-value
 		text-align: left
 		margin-top: unset


### PR DESCRIPTION
_Screenshot in Safari Version 15.2 (17612.3.6.1.6):_

<img width="686" alt="Screenshot in Safari 2022-01-19 at 13 12 34" src="https://user-images.githubusercontent.com/387611/150127339-b8d924d6-1186-4b10-bf92-2b55baeb699a.png">


Closes https://github.com/contember/private-issues/issues/49

### Checks
- [x] The changes and implementation strategy have been consulted with the maintainers.
- [x] The code passes all the checks (Run `pnpm run check`).
