### PR TITLE
Pages: lower case first letter of page named based on export

### DIFF
--- a/packages/admin/src/components/pageRouting/Pages.tsx
+++ b/packages/admin/src/components/pageRouting/Pages.tsx
@@ -79,7 +79,7 @@ export const Pages = ({ children, layout }: PagesProps) => {
 					} else if (isPageProviderElement(v)) {
 						return [[v.type.getPageName(v.props), () => v]]
 					} else {
-						return [[k, v]]
+						return [[k.slice(0, 1).toLowerCase() + k.slice(1), v]]
 					}
 				}))
 			}


### PR DESCRIPTION
Because component name in React should aways start with uppercase letter, we need to normalize it back to lowercase when using it as page name.

~~~tsx
export const index = (
	<GenericPage pageName="index">
		Welcome to Contember Admin!
	</GenericPage>
)
~~~

~~~tsx
export const Index = () => (
	<GenericPage pageName="index">
		Welcome to Contember Admin!
	</GenericPage>
)
~~~