### PR TITLE
Include `@font-face` declarations by default

### DIFF
--- a/packages/admin/src/styles/_globalOverrides.sass
+++ b/packages/admin/src/styles/_globalOverrides.sass
@@ -5,7 +5,7 @@ html, body
 	padding: 0
 
 body
-	font-family: $font-family-base
+	font-family: var(--cui-font-family)
 	line-height: var(--cui-line-height)
 	margin: 0
 	padding: 0

--- a/packages/admin/src/styles/_globalOverrides.sass
+++ b/packages/admin/src/styles/_globalOverrides.sass
@@ -1,29 +1,5 @@
 @import 'common'
 
-html, body
-	margin: 0
-	padding: 0
-
-body
-	font-family: var(--cui-font-family)
-	line-height: var(--cui-line-height)
-	margin: 0
-	padding: 0
-	font-smoothing: antialiased
-	min-width: 100vw
-	@media (min-width: $breakpoint-min-medium)
-		width: fit-content
-	-webkit-font-smoothing: antialiased
-
-h1, h2, h3, h4, h5, h6
-	font-weight: $fw-medium
-
-textarea
-	resize: vertical
-
-a
-	text-decoration: none
-
 .bp3-icon
 	display: inline-flex
 	justify-content: center

--- a/packages/admin/src/styles/_variables.sass
+++ b/packages/admin/src/styles/_variables.sass
@@ -13,10 +13,6 @@ $spacing: $spacing-normal
 $padding: $spacing-small
 
 // Font properties
-$font-family-sans-serif: Poppins, Roboto, $font-family-sans-serif-fallback
-$font-family-base: $font-family-sans-serif
-$font-family-head: $font-family-sans-serif
-
 $fs-tiny: rem(12px)
 $fs-small: rem(14px)
 $fs-normal: rem(16px)

--- a/packages/ui/src/styles/_customProperties.sass
+++ b/packages/ui/src/styles/_customProperties.sass
@@ -8,6 +8,8 @@
 	--cui-transition-duration--slow: 600ms
 	--cui-transition-duration--slowest: 800ms
 
+	--cui-font-family: Poppins, Roboto, #{$font-family-sans-serif-fallback}
+
 	--cui-line-height: 1.5
 	--cui-font-size-heading: #{em(16px)}
 	--cui-font-size-body: #{em(14px)}

--- a/packages/ui/src/styles/_root.sass
+++ b/packages/ui/src/styles/_root.sass
@@ -23,6 +23,29 @@ $cui-buildState-alreadyOutputRoot: false !default
 		--cui-control-focus-ring-box-shadow: 0 0 0 .2em var(--cui-control-border-color)
 		--cui-control-focus-ring-box-shadow-error: 0 0 0 .2em rgb(var(--cui-theme-danger-500))
 
+	html, body
+		margin: 0
+		padding: 0
+
+	body
+		font-family: var(--cui-font-family)
+		line-height: var(--cui-line-height)
+		margin: 0
+		padding: 0
+		font-smoothing: antialiased
+		min-width: 100vw
+		@media (min-width: $breakpoint-min-medium)
+			width: fit-content
+		-webkit-font-smoothing: antialiased
+
+	h1, h2, h3, h4, h5, h6
+		font-weight: $fw-medium
+
+	textarea
+		resize: vertical
+
+	a
+		text-decoration: none
 	a, button
 		color: var(--cui-control-color)
 		font-weight: 600

--- a/packages/ui/src/styles/index.sass
+++ b/packages/ui/src/styles/index.sass
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap')
+
 @import 'common'
 @import 'animations/index'
 @import 'abstract/index'


### PR DESCRIPTION
Note: Only used font weights are being downloaded, see Font loading section of https://web.dev/font-best-practices/

Closes #

### Checks
- [x] The changes and implementation strategy have been consulted with the maintainers.
- [x] The code passes all the checks (Run `pnpm run check`).
