### PR TITLE
Fix empty slug leaving `hasUnpersistedChanges()` set to true

### DIFF
--- a/packages/admin/src/components/bindingFacade/fields/SlugField.tsx
+++ b/packages/admin/src/components/bindingFacade/fields/SlugField.tsx
@@ -67,7 +67,12 @@ export const SlugFieldInner = SimpleRelativeSingleField<SlugFieldProps, string>(
 		})
 		const transform = useCallback(
 			(driverFieldValue: string | null) => {
-				const slugValue = slugify(driverFieldValue || '')
+				if (driverFieldValue === null) {
+					return null
+				}
+
+				const slugValue = slugify(driverFieldValue)
+
 				return `${normalizedPersistedHardPrefix}${normalizedPersistedSoftPrefix}${slugValue}`
 			},
 			[normalizedPersistedHardPrefix, normalizedPersistedSoftPrefix],


### PR DESCRIPTION
### Checks
- [x] The changes and implementation strategy have been consulted with the maintainers.
- [x] The code passes all the checks (Run `pnpm run check`).
