### PR TITLE
Hotfix: BlockEditor.tsx

### DIFF
--- a/packages/admin/src/components/bindingFacade/richText/blockEditor/BlockEditor.tsx
+++ b/packages/admin/src/components/bindingFacade/richText/blockEditor/BlockEditor.tsx
@@ -189,7 +189,7 @@ const BlockEditorComponent: FunctionComponent<BlockEditorProps> = Component(
 		const trailingElements = useFieldBackedElementFields(trailingFieldBackedElements)
 
 		return (
-			<FieldContainer label={label}>
+			<FieldContainer label={label} useLabelElement={false}>
 				<ReferencesProvider getReferencedEntity={getReferencedEntity}>
 					<SortedBlocksContext.Provider value={sortedBlocksRef.current}>
 						<SortableRepeaterContainer


### PR DESCRIPTION
`<label>` has special _powers_ (focusing input within its children) but when used on the content editor renders it unusable. FieldContainer around the content editor uses such `<label>` by default and needs to be disabled for this special use-case.

### Checks
- [x] The changes and implementation strategy have been consulted with the maintainers.
- [x] The code passes all the checks (Run `pnpm run check`).
