### PR TITLE
Fix display of `EmptyMessage` component

### DIFF
--- a/packages/admin/src/components/bindingFacade/collections/DataGrid/base/DataGridContainer.tsx
+++ b/packages/admin/src/components/bindingFacade/collections/DataGrid/base/DataGridContainer.tsx
@@ -167,7 +167,12 @@ export const DataGridContainer: FunctionComponent<DataGridContainerProps> = Comp
 					{!accessor.length && (
 						<TableRow>
 							<TableCell colSpan={columns.size}>
-								<EmptyMessage component={emptyMessageComponent}>{formatMessage(emptyMessage, 'dataGrid.emptyMessage.text')}</EmptyMessage>
+								<EmptyMessage
+									distinction="seamless"
+									component={emptyMessageComponent}
+								>
+									{formatMessage(emptyMessage, 'dataGrid.emptyMessage.text')}
+								</EmptyMessage>
 							</TableCell>
 						</TableRow>
 					)}

--- a/packages/admin/src/components/bindingFacade/collections/helpers/EmptyMessage.tsx
+++ b/packages/admin/src/components/bindingFacade/collections/helpers/EmptyMessage.tsx
@@ -1,4 +1,4 @@
-import { Message } from '@contember/ui'
+import { Box, BoxProps, Stack } from '@contember/ui'
 import { ComponentType, memo, ReactNode } from 'react'
 
 export interface EmptyMessageOuterProps {
@@ -9,18 +9,25 @@ export interface EmptyMessageOuterProps {
 export interface EmptyMessageProps {
 	children: ReactNode
 	component?: ComponentType<EmptyMessageComponentProps>
+	distinction?: BoxProps['distinction']
 }
 
 export interface EmptyMessageComponentProps {
 	children: ReactNode
+	distinction?: BoxProps['distinction']
 }
 
-export const EmptyMessage = memo(({ children, component }: EmptyMessageProps) => {
+export const EmptyMessage = memo(({ children, component, distinction }: EmptyMessageProps) => {
 	const MessageComponent = component ?? EmptyMessageDefault
-	return <MessageComponent>{children}</MessageComponent>
+	return <MessageComponent distinction={distinction}>{children}</MessageComponent>
 })
 EmptyMessage.displayName = 'EmptyMessage'
 
-const EmptyMessageDefault = memo((props: EmptyMessageComponentProps) => (
-	<Message flow="generousBlock">{props.children}</Message>
+const EmptyMessageDefault = memo(({ children, distinction }: EmptyMessageComponentProps) => (
+	<Box distinction={distinction} intent="default">
+		<Stack
+			direction="horizontal"
+			justify="space-around"
+		>{children}</Stack>
+	</Box>
 ))

--- a/packages/ui/src/components/Box/Box.sass
+++ b/packages/ui/src/components/Box/Box.sass
@@ -32,7 +32,6 @@
 		box-shadow: none
 		background: inherit
 		border: 0
-		padding: 0
 		border-radius: unset
 	&.view-no-padding
 		--cui-box-content-padding: 0


### PR DESCRIPTION
- Fixes display of message components (defaultly meant to be used outside of the table cess)
- Seamless should not remove `Box` padding, there's an explicit padding prop for that (fix)

Closes #

### Checks
- [x] The changes and implementation strategy have been consulted with the maintainers.
- [x] The code passes all the checks (Run `pnpm run check`).
