### PR TITLE
Remove `disabled: false` radio option attribute

### DIFF
--- a/packages/admin/src/components/bindingFacade/fields/RadioField.tsx
+++ b/packages/admin/src/components/bindingFacade/fields/RadioField.tsx
@@ -50,13 +50,13 @@ export interface RadioFieldInnerProps extends ChoiceFieldData.SingleChoiceFieldM
 
 export const RadioFieldInner = memo((props: RadioFieldInnerProps) => {
 	const options: RadioOption[] = props.data.map(({ key, label, description }) => {
-			return {
-				disabled: false,
-				value: key.toString(),
-				label: label,
-				labelDescription: description,
-			}
-		})
+		return {
+			value: key.toString(),
+			label: label,
+			labelDescription: description,
+		}
+	})
+
 	return (
 		<FieldContainer
 			{...props}


### PR DESCRIPTION
RadioOption interface is defined [here](https://github.com/contember/admin/blob/8f15227c8cbe80ed5eaf7367fdc74048829fb9db/packages/ui/src/components/forms/RadioGroup/types.ts#L3), `disabled` attribure is not present:

```ts
export interface RadioOption {
	label: ReactNode
	labelDescription?: ReactNode
	value: string
}
```

### Checks
- [x] The changes and implementation strategy have been consulted with the maintainers.
- [x] The code passes all the checks (Run `pnpm run check`).
