### PR TITLE
Package: add link to GitHub repository

### DIFF
--- a/packages/admin-i18n/package.json
+++ b/packages/admin-i18n/package.json
@@ -18,6 +18,11 @@
 		"src/"
 	],
 	"typings": "./dist/types/index.d.ts",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/contember/admin.git",
+		"directory": "packages/admin-i18n"
+	},
 	"scripts": {
 		"build": "vite build --mode development && vite build --mode production"
 	},

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -19,6 +19,11 @@
 		"src/"
 	],
 	"typings": "./dist/types/index.d.ts",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/contember/admin.git",
+		"directory": "packages/admin"
+	},
 	"scripts": {
 		"build": "pnpm run build:js && pnpm run build:css",
 		"build:js": "vite build --mode development && vite build --mode production",


### PR DESCRIPTION
This pull request adds link to GitHub repository so registries like [npmjs](https://www.npmjs.com/package/@contember/admin) can link to it.

![image](https://user-images.githubusercontent.com/1045362/156768037-d6e64f5c-f0b6-4c52-855a-03ea6ba71d52.png)

