### PR TITLE
Button: Fix focus ring

### DIFF
--- a/packages/ui/src/components/Forms/Button/Button.sass
+++ b/packages/ui/src/components/Forms/Button/Button.sass
@@ -119,8 +119,8 @@
 		--cui-button-background-color: transparent
 		--cui-button-background-color--highlighted: var(--cui-control-background-color--highlighted)
 		--cui-button-background-color--pressed: var(--cui-control-background-color--pressed)
-		--cui-button-box-shadow--highlighted: none
-		--cui-button-box-shadow: none
+		--cui-button-box-shadow--highlighted: 0 0 transparent
+		--cui-button-box-shadow: 0 0 transparent
 		--cui-button-color: var(--cui-control-color)
 		--cui-button-color--highlighted: var(--cui-control-color--highlighted)
 		--cui-button-color--pressed: var(--cui-control-color--pressed)


### PR DESCRIPTION
Issue: `none` disables other box-shadow rules

### Checks
- [x] The changes and implementation strategy have been consulted with the maintainers.
- [x] The code passes all the checks (Run `pnpm run check`).
