### PR TITLE
Improve theming

### DIFF
--- a/packages/admin/src/components/bindingFacade/buttons/PersistButton.tsx
+++ b/packages/admin/src/components/bindingFacade/buttons/PersistButton.tsx
@@ -29,7 +29,6 @@ export const PersistButton = memo((props: PersistButtonProps) => {
 			isDirty={isDirty}
 			isLoading={isMutating}
 			onClick={onClick}
-			scheme="dark"
 			size="large"
 			{...props}
 		/>

--- a/packages/admin/src/components/bindingFacade/collections/helpers/DeleteEntityButton.tsx
+++ b/packages/admin/src/components/bindingFacade/collections/helpers/DeleteEntityButton.tsx
@@ -37,7 +37,7 @@ export const DeleteEntityButton = memo((props: DeleteEntityButtonProps) => {
 	}
 
 	return (
-		<Button scheme="dark" {...defaultProps} {...rest} className={classNames(
+		<Button distinction="primary" {...defaultProps} {...rest} className={classNames(
 			className,
 			'theme-grey-controls',
 			'theme-danger-controls:hover',

--- a/packages/admin/src/tenant/components/person/Login.tsx
+++ b/packages/admin/src/tenant/components/person/Login.tsx
@@ -73,7 +73,7 @@ export const Login = ({ onLogin, resetLink }: LoginProps) => {
 					/>
 				</FieldContainer>}
 				<Stack direction="horizontal" align="center" justify="space-between">
-					<Button type="submit" scheme="dark" intent="primary" disabled={isSubmitting}>
+					<Button type="submit" intent="primary" distinction="primary" disabled={isSubmitting}>
 						Submit
 					</Button>
 					{resetLink && <Link to={resetLink}>Forgot your password?</Link>}

--- a/packages/ui/src/components/Forms/Button/Button.sass
+++ b/packages/ui/src/components/Forms/Button/Button.sass
@@ -23,8 +23,8 @@
 	--cui-button-color--highlighted: var(--cui-filled-control-color--highlighted)
 	--cui-button-color--disabled: var(--cui-color--low)
 	--cui-button-color--pressed: var(--cui-filled-control-color--pressed)
-	--cui-button-background-color: var(--cui-filled-control-background-color)
-	--cui-button-background-color--highlighted: var(--cui-filled-control-background-color--highlighted)
+	--cui-button-background-color: var(--cui-filled-background-color)
+	--cui-button-background-color--highlighted: var(--cui-filled-background-color--highlighted)
 	--cui-button-background-color--pressed: linear-gradient(180deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.05)), var(--cui-filled-control-background-color--pressed)
 	--cui-button-background-color--disabled: var(--cui-toned-control-background-color)
 	--cui-button-border-color: rgba(0, 0, 0, 0)
@@ -128,6 +128,13 @@
 			--cui-button-height: auto
 			--cui-button-padding-horizontal: calc(var(--cui-gap) - #{$border-width-em})
 		position: relative
+	&.view-primary
+		--cui-button-color: var(--cui-filled-primary-control-color)
+		--cui-button-color--highlighted: var(--cui-filled-primary-control-color--highlighted)
+		--cui-button-color--pressed: var(--cui-filled-primary-control-color--pressed)
+		--cui-button-background-color: var(--cui-filled-primary-control-background-color)
+		--cui-button-background-color--highlighted: var(--cui-filled-primary-control-background-color--highlighted)
+		--cui-button-background-color--pressed: linear-gradient(180deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.05)), var(--cui-filled-primary-control-background-color--pressed)
 	&.view-toned
 		--cui-button-background-color: var(--cui-toned-control-background-color)
 		--cui-button-background-color--highlighted: var(--cui-toned-control-background-color--highlighted)

--- a/packages/ui/src/components/Layout/LayoutChrome.sass
+++ b/packages/ui/src/components/Layout/LayoutChrome.sass
@@ -36,6 +36,7 @@
 		height: 100vh
 		left: 0
 		max-height: 100vh
+		max-width: $breakpoint-max-xsmall
 		position: sticky
 		top: 0
 		z-index: 2
@@ -49,9 +50,6 @@
 		padding-right: var(--cui-layout-chrome-padding-right)
 		padding-top: var(--cui-layout-chrome-padding-top)
 		position: relative
-		&-inner
-			flex: 1
-			overflow: hidden
 	&-bar-body
 		border-top: 1px solid transparent
 		flex-grow: 1

--- a/packages/ui/src/components/Menu/Menu.sass
+++ b/packages/ui/src/components/Menu/Menu.sass
@@ -26,6 +26,7 @@
 
 	&-expand-toggle
 		--cui-expand-toggle-size: calc(5 * var(--cui-gap))
+		background: transparent
 		border: 0
 		color: inherit
 		height: var(--cui-expand-toggle-size)

--- a/packages/ui/src/components/Menu/Menu.sass
+++ b/packages/ui/src/components/Menu/Menu.sass
@@ -109,8 +109,11 @@
 
 	&-group
 		&.is-interactive > &-title
-			color: var(--cui-control-color)
+			color: var(--cui-color--strong)
 		&-list
 			list-style: none
 			padding-left: calc(4 * var(--cui-gap-horizontal))
 			position: relative
+
+a.#{$cui-conf-globalPrefix}menu-group-title-content .#{$cui-conf-globalPrefix}menu-group-title-label
+	color: var(--cui-color--strong)

--- a/packages/ui/src/components/SaveButton.tsx
+++ b/packages/ui/src/components/SaveButton.tsx
@@ -25,8 +25,8 @@ export const SaveButton = memo(
 			ref={ref}
 			size={size ?? 'large'}
 			flow={flow ?? 'block'}
-			scheme={isPrimary ? 'dark' : scheme }
-			distinction={rest.disabled ? 'seamless' : distinction}
+			scheme={scheme}
+			distinction={rest.disabled ? 'seamless' : isPrimary ? 'primary' : distinction}
 			{...rest}
 			>
 				{isDirty

--- a/packages/ui/src/components/Typography/Label.sass
+++ b/packages/ui/src/components/Typography/Label.sass
@@ -11,7 +11,7 @@
 	font-family: inherit
 	font-size: var(--cui-font-size-label)
 	font-weight: inherit
-	line-height: 1em
+	line-height: 1.125em
 	margin: calc(-1 * var(--cui-inset-vertical)) calc(-1 * var(--cui-inset-horizontal))
 	padding: var(--cui-inset-vertical) var(--cui-inset-horizontal)
 	position: relative

--- a/packages/ui/src/components/Typography/Label.sass
+++ b/packages/ui/src/components/Typography/Label.sass
@@ -28,6 +28,9 @@
 		font-weight: lighter
 		font-size: var(--cui-font-size-heading)
 
+	a &, button &
+		color: var(--cui-control-color)
+
 	&.is-active
 		color: var(--cui-control-color--highlighted)
 		z-index: 1

--- a/packages/ui/src/styles/_themeSchemes.css
+++ b/packages/ui/src/styles/_themeSchemes.css
@@ -1,347 +1,347 @@
 /*** All color swatches: ***/
 :root {
-	/** primary: #15009C **/
+	/** primary: #000067 **/
 	--cui-theme-primary-1000: 255, 255, 255;
-	--cui-theme-primary-975: 243, 244, 255;
-	--cui-theme-primary-950: 230, 233, 255;
-	--cui-theme-primary-925: 218, 223, 255;
-	--cui-theme-primary-900: 206, 214, 255;
-	--cui-theme-primary-875: 194, 204, 255;
-	--cui-theme-primary-850: 182, 195, 255;
-	--cui-theme-primary-825: 170, 186, 255;
-	--cui-theme-primary-800: 157, 178, 255;
-	--cui-theme-primary-775: 142, 171, 255;
-	--cui-theme-primary-750: 127, 163, 255;
-	--cui-theme-primary-725: 115, 156, 252;
-	--cui-theme-primary-700: 107, 148, 248;
-	--cui-theme-primary-675: 100, 140, 245;
-	--cui-theme-primary-650: 93, 133, 243;
-	--cui-theme-primary-625: 85, 125, 240;
-	--cui-theme-primary-600: 75, 118, 238;
-	--cui-theme-primary-575: 66, 112, 235;
-	--cui-theme-primary-550: 56, 105, 233;
-	--cui-theme-primary-525: 42, 98, 230;
-	--cui-theme-primary-500: 23, 92, 228;
-	--cui-theme-primary-475: 2, 86, 225;
-	--cui-theme-primary-450: 4, 80, 217;
-	--cui-theme-primary-425: 6, 74, 210;
-	--cui-theme-primary-400: 8, 68, 203;
-	--cui-theme-primary-375: 9, 62, 197;
-	--cui-theme-primary-350: 8, 57, 190;
-	--cui-theme-primary-325: 8, 51, 183;
-	--cui-theme-primary-300: 7, 45, 177;
-	--cui-theme-primary-275: 6, 40, 170;
-	--cui-theme-primary-250: 4, 33, 164;
-	--cui-theme-primary-225: 2, 27, 157;
-	--cui-theme-primary-200: 1, 21, 150;
-	--cui-theme-primary-175: 8, 18, 137;
-	--cui-theme-primary-150: 12, 15, 124;
-	--cui-theme-primary-125: 14, 12, 110;
-	--cui-theme-primary-100: 16, 9, 95;
-	--cui-theme-primary-75: 15, 6, 80;
-	--cui-theme-primary-50: 15, 7, 53;
-	--cui-theme-primary-25: 10, 5, 23;
+	--cui-theme-primary-975: 245, 250, 255;
+	--cui-theme-primary-950: 236, 244, 255;
+	--cui-theme-primary-925: 227, 238, 255;
+	--cui-theme-primary-900: 218, 231, 255;
+	--cui-theme-primary-875: 211, 225, 255;
+	--cui-theme-primary-850: 203, 219, 255;
+	--cui-theme-primary-825: 196, 212, 255;
+	--cui-theme-primary-800: 191, 207, 255;
+	--cui-theme-primary-775: 185, 201, 255;
+	--cui-theme-primary-750: 180, 196, 255;
+	--cui-theme-primary-725: 176, 190, 255;
+	--cui-theme-primary-700: 171, 185, 255;
+	--cui-theme-primary-675: 168, 180, 255;
+	--cui-theme-primary-650: 163, 175, 255;
+	--cui-theme-primary-625: 159, 169, 255;
+	--cui-theme-primary-600: 155, 164, 255;
+	--cui-theme-primary-575: 151, 158, 255;
+	--cui-theme-primary-550: 147, 152, 255;
+	--cui-theme-primary-525: 144, 144, 255;
+	--cui-theme-primary-500: 138, 138, 251;
+	--cui-theme-primary-475: 131, 131, 247;
+	--cui-theme-primary-450: 124, 124, 243;
+	--cui-theme-primary-425: 116, 116, 238;
+	--cui-theme-primary-400: 108, 108, 233;
+	--cui-theme-primary-375: 99, 99, 227;
+	--cui-theme-primary-350: 90, 90, 220;
+	--cui-theme-primary-325: 81, 81, 213;
+	--cui-theme-primary-300: 71, 71, 206;
+	--cui-theme-primary-275: 61, 61, 197;
+	--cui-theme-primary-250: 51, 51, 189;
+	--cui-theme-primary-225: 41, 41, 179;
+	--cui-theme-primary-200: 29, 29, 169;
+	--cui-theme-primary-175: 17, 17, 158;
+	--cui-theme-primary-150: 3, 3, 145;
+	--cui-theme-primary-125: 0, 0, 125;
+	--cui-theme-primary-100: 0, 0, 104;
+	--cui-theme-primary-75: 0, 0, 84;
+	--cui-theme-primary-50: 0, 0, 65;
+	--cui-theme-primary-25: 0, 0, 42;
 	--cui-theme-primary-0: 0, 0, 0;
 
 	/** secondary: #3DA9EB **/
 	--cui-theme-secondary-1000: 255, 255, 255;
-	--cui-theme-secondary-975: 206, 253, 255;
-	--cui-theme-secondary-950: 160, 249, 255;
-	--cui-theme-secondary-925: 111, 244, 254;
-	--cui-theme-secondary-900: 73, 236, 250;
-	--cui-theme-secondary-875: 39, 227, 245;
-	--cui-theme-secondary-850: 16, 218, 238;
-	--cui-theme-secondary-825: 2, 208, 232;
-	--cui-theme-secondary-800: 6, 199, 228;
-	--cui-theme-secondary-775: 8, 189, 223;
-	--cui-theme-secondary-750: 8, 180, 220;
-	--cui-theme-secondary-725: 7, 172, 216;
-	--cui-theme-secondary-700: 4, 164, 211;
-	--cui-theme-secondary-675: 1, 155, 208;
-	--cui-theme-secondary-650: 1, 148, 201;
-	--cui-theme-secondary-625: 1, 141, 194;
-	--cui-theme-secondary-600: 2, 134, 186;
-	--cui-theme-secondary-575: 2, 128, 180;
-	--cui-theme-secondary-550: 1, 121, 174;
-	--cui-theme-secondary-525: 1, 115, 167;
-	--cui-theme-secondary-500: 1, 109, 162;
-	--cui-theme-secondary-475: 0, 103, 155;
-	--cui-theme-secondary-450: 0, 98, 147;
-	--cui-theme-secondary-425: 0, 93, 139;
-	--cui-theme-secondary-400: 0, 87, 131;
-	--cui-theme-secondary-375: 0, 83, 123;
-	--cui-theme-secondary-350: 0, 78, 115;
-	--cui-theme-secondary-325: 0, 73, 107;
-	--cui-theme-secondary-300: 0, 69, 100;
-	--cui-theme-secondary-275: 0, 64, 92;
-	--cui-theme-secondary-250: 0, 59, 85;
-	--cui-theme-secondary-225: 0, 55, 77;
-	--cui-theme-secondary-200: 1, 50, 70;
-	--cui-theme-secondary-175: 1, 46, 63;
-	--cui-theme-secondary-150: 1, 41, 56;
-	--cui-theme-secondary-125: 1, 36, 48;
-	--cui-theme-secondary-100: 1, 31, 41;
-	--cui-theme-secondary-75: 1, 25, 32;
-	--cui-theme-secondary-50: 0, 18, 23;
-	--cui-theme-secondary-25: 0, 10, 12;
+	--cui-theme-secondary-975: 244, 250, 254;
+	--cui-theme-secondary-950: 232, 245, 253;
+	--cui-theme-secondary-925: 220, 240, 251;
+	--cui-theme-secondary-900: 209, 234, 250;
+	--cui-theme-secondary-875: 197, 229, 249;
+	--cui-theme-secondary-850: 185, 224, 248;
+	--cui-theme-secondary-825: 174, 219, 247;
+	--cui-theme-secondary-800: 163, 214, 246;
+	--cui-theme-secondary-775: 153, 210, 244;
+	--cui-theme-secondary-750: 143, 205, 243;
+	--cui-theme-secondary-725: 134, 201, 242;
+	--cui-theme-secondary-700: 124, 197, 242;
+	--cui-theme-secondary-675: 115, 193, 241;
+	--cui-theme-secondary-650: 105, 189, 240;
+	--cui-theme-secondary-625: 96, 184, 239;
+	--cui-theme-secondary-600: 85, 180, 238;
+	--cui-theme-secondary-575: 74, 175, 236;
+	--cui-theme-secondary-550: 63, 170, 235;
+	--cui-theme-secondary-525: 59, 164, 228;
+	--cui-theme-secondary-500: 57, 158, 220;
+	--cui-theme-secondary-475: 55, 152, 211;
+	--cui-theme-secondary-450: 52, 145, 201;
+	--cui-theme-secondary-425: 50, 137, 191;
+	--cui-theme-secondary-400: 47, 130, 180;
+	--cui-theme-secondary-375: 44, 121, 169;
+	--cui-theme-secondary-350: 41, 113, 157;
+	--cui-theme-secondary-325: 38, 104, 145;
+	--cui-theme-secondary-300: 34, 95, 133;
+	--cui-theme-secondary-275: 31, 87, 120;
+	--cui-theme-secondary-250: 28, 78, 108;
+	--cui-theme-secondary-225: 25, 69, 96;
+	--cui-theme-secondary-200: 22, 60, 83;
+	--cui-theme-secondary-175: 18, 51, 71;
+	--cui-theme-secondary-150: 15, 43, 60;
+	--cui-theme-secondary-125: 13, 35, 48;
+	--cui-theme-secondary-100: 10, 27, 38;
+	--cui-theme-secondary-75: 7, 20, 28;
+	--cui-theme-secondary-50: 5, 14, 19;
+	--cui-theme-secondary-25: 2, 6, 9;
 	--cui-theme-secondary-0: 0, 0, 0;
 
 	/** tertiary: #AE65FF **/
 	--cui-theme-tertiary-1000: 255, 255, 255;
-	--cui-theme-tertiary-975: 252, 241, 255;
-	--cui-theme-tertiary-950: 249, 228, 255;
-	--cui-theme-tertiary-925: 247, 214, 255;
-	--cui-theme-tertiary-900: 244, 201, 255;
-	--cui-theme-tertiary-875: 241, 188, 255;
-	--cui-theme-tertiary-850: 238, 175, 255;
-	--cui-theme-tertiary-825: 235, 163, 255;
-	--cui-theme-tertiary-800: 234, 149, 255;
-	--cui-theme-tertiary-775: 236, 133, 255;
-	--cui-theme-tertiary-750: 229, 123, 255;
-	--cui-theme-tertiary-725: 222, 113, 255;
-	--cui-theme-tertiary-700: 212, 105, 252;
-	--cui-theme-tertiary-675: 203, 98, 249;
-	--cui-theme-tertiary-650: 194, 90, 246;
-	--cui-theme-tertiary-625: 185, 82, 244;
-	--cui-theme-tertiary-600: 176, 75, 242;
-	--cui-theme-tertiary-575: 168, 68, 239;
-	--cui-theme-tertiary-550: 159, 60, 237;
-	--cui-theme-tertiary-525: 150, 53, 235;
-	--cui-theme-tertiary-500: 142, 45, 233;
-	--cui-theme-tertiary-475: 135, 41, 223;
-	--cui-theme-tertiary-450: 129, 37, 213;
-	--cui-theme-tertiary-425: 123, 32, 204;
-	--cui-theme-tertiary-400: 117, 28, 194;
-	--cui-theme-tertiary-375: 112, 24, 185;
-	--cui-theme-tertiary-350: 106, 19, 176;
-	--cui-theme-tertiary-325: 100, 15, 167;
-	--cui-theme-tertiary-300: 95, 9, 159;
-	--cui-theme-tertiary-275: 90, 3, 150;
-	--cui-theme-tertiary-250: 84, 0, 142;
-	--cui-theme-tertiary-225: 79, 0, 130;
-	--cui-theme-tertiary-200: 74, 0, 118;
-	--cui-theme-tertiary-175: 68, 0, 107;
-	--cui-theme-tertiary-150: 62, 0, 96;
-	--cui-theme-tertiary-125: 55, 2, 83;
-	--cui-theme-tertiary-100: 47, 5, 68;
-	--cui-theme-tertiary-75: 37, 7, 54;
-	--cui-theme-tertiary-50: 27, 7, 38;
-	--cui-theme-tertiary-25: 14, 5, 19;
+	--cui-theme-tertiary-975: 251, 248, 255;
+	--cui-theme-tertiary-950: 247, 240, 255;
+	--cui-theme-tertiary-925: 243, 233, 255;
+	--cui-theme-tertiary-900: 239, 225, 255;
+	--cui-theme-tertiary-875: 235, 217, 255;
+	--cui-theme-tertiary-850: 231, 210, 255;
+	--cui-theme-tertiary-825: 228, 203, 255;
+	--cui-theme-tertiary-800: 224, 196, 255;
+	--cui-theme-tertiary-775: 221, 190, 255;
+	--cui-theme-tertiary-750: 218, 184, 255;
+	--cui-theme-tertiary-725: 214, 178, 255;
+	--cui-theme-tertiary-700: 211, 172, 255;
+	--cui-theme-tertiary-675: 208, 166, 255;
+	--cui-theme-tertiary-650: 205, 161, 255;
+	--cui-theme-tertiary-625: 202, 155, 255;
+	--cui-theme-tertiary-600: 199, 148, 255;
+	--cui-theme-tertiary-575: 195, 142, 255;
+	--cui-theme-tertiary-550: 192, 135, 255;
+	--cui-theme-tertiary-525: 188, 127, 255;
+	--cui-theme-tertiary-500: 184, 119, 255;
+	--cui-theme-tertiary-475: 179, 110, 255;
+	--cui-theme-tertiary-450: 173, 100, 253;
+	--cui-theme-tertiary-425: 164, 95, 240;
+	--cui-theme-tertiary-400: 155, 90, 227;
+	--cui-theme-tertiary-375: 145, 84, 212;
+	--cui-theme-tertiary-350: 135, 78, 198;
+	--cui-theme-tertiary-325: 125, 72, 182;
+	--cui-theme-tertiary-300: 114, 66, 167;
+	--cui-theme-tertiary-275: 104, 60, 152;
+	--cui-theme-tertiary-250: 93, 54, 136;
+	--cui-theme-tertiary-225: 82, 48, 121;
+	--cui-theme-tertiary-200: 72, 42, 105;
+	--cui-theme-tertiary-175: 61, 36, 90;
+	--cui-theme-tertiary-150: 51, 30, 75;
+	--cui-theme-tertiary-125: 42, 24, 61;
+	--cui-theme-tertiary-100: 33, 19, 48;
+	--cui-theme-tertiary-75: 24, 14, 36;
+	--cui-theme-tertiary-50: 16, 9, 24;
+	--cui-theme-tertiary-25: 8, 4, 11;
 	--cui-theme-tertiary-0: 0, 0, 0;
 
-	/** positive: #4390FF **/
+	/** positive: #006AFF **/
 	--cui-theme-positive-1000: 255, 255, 255;
-	--cui-theme-positive-975: 211, 252, 255;
-	--cui-theme-positive-950: 175, 247, 255;
-	--cui-theme-positive-925: 150, 238, 255;
-	--cui-theme-positive-900: 134, 229, 255;
-	--cui-theme-positive-875: 125, 218, 255;
-	--cui-theme-positive-850: 108, 209, 255;
-	--cui-theme-positive-825: 91, 201, 255;
-	--cui-theme-positive-800: 73, 192, 255;
-	--cui-theme-positive-775: 65, 183, 252;
-	--cui-theme-positive-750: 61, 174, 249;
-	--cui-theme-positive-725: 57, 165, 245;
-	--cui-theme-positive-700: 52, 157, 242;
-	--cui-theme-positive-675: 46, 148, 240;
-	--cui-theme-positive-650: 39, 140, 237;
-	--cui-theme-positive-625: 31, 133, 235;
-	--cui-theme-positive-600: 19, 125, 232;
-	--cui-theme-positive-575: 0, 118, 230;
-	--cui-theme-positive-550: 2, 111, 225;
-	--cui-theme-positive-525: 3, 104, 218;
-	--cui-theme-positive-500: 3, 98, 214;
-	--cui-theme-positive-475: 2, 91, 208;
-	--cui-theme-positive-450: 0, 85, 202;
-	--cui-theme-positive-425: 0, 81, 192;
-	--cui-theme-positive-400: 0, 76, 182;
-	--cui-theme-positive-375: 0, 71, 172;
-	--cui-theme-positive-350: 0, 67, 163;
-	--cui-theme-positive-325: 0, 62, 155;
-	--cui-theme-positive-300: 0, 58, 145;
-	--cui-theme-positive-275: 0, 54, 137;
-	--cui-theme-positive-250: 0, 50, 127;
-	--cui-theme-positive-225: 0, 46, 117;
-	--cui-theme-positive-200: 1, 43, 106;
-	--cui-theme-positive-175: 1, 39, 95;
-	--cui-theme-positive-150: 1, 35, 85;
-	--cui-theme-positive-125: 1, 31, 75;
-	--cui-theme-positive-100: 1, 26, 64;
-	--cui-theme-positive-75: 1, 22, 51;
-	--cui-theme-positive-50: 0, 16, 37;
-	--cui-theme-positive-25: 0, 9, 20;
+	--cui-theme-positive-975: 245, 249, 255;
+	--cui-theme-positive-950: 236, 244, 255;
+	--cui-theme-positive-925: 226, 238, 255;
+	--cui-theme-positive-900: 216, 232, 255;
+	--cui-theme-positive-875: 206, 226, 255;
+	--cui-theme-positive-850: 196, 221, 255;
+	--cui-theme-positive-825: 187, 215, 255;
+	--cui-theme-positive-800: 178, 210, 255;
+	--cui-theme-positive-775: 169, 205, 255;
+	--cui-theme-positive-750: 161, 200, 255;
+	--cui-theme-positive-725: 153, 196, 255;
+	--cui-theme-positive-700: 146, 191, 255;
+	--cui-theme-positive-675: 138, 187, 255;
+	--cui-theme-positive-650: 131, 182, 255;
+	--cui-theme-positive-625: 123, 178, 255;
+	--cui-theme-positive-600: 114, 173, 255;
+	--cui-theme-positive-575: 106, 168, 255;
+	--cui-theme-positive-550: 96, 162, 255;
+	--cui-theme-positive-525: 86, 157, 255;
+	--cui-theme-positive-500: 75, 150, 255;
+	--cui-theme-positive-475: 63, 143, 255;
+	--cui-theme-positive-450: 49, 135, 255;
+	--cui-theme-positive-425: 34, 126, 255;
+	--cui-theme-positive-400: 17, 116, 255;
+	--cui-theme-positive-375: 0, 105, 252;
+	--cui-theme-positive-350: 0, 98, 235;
+	--cui-theme-positive-325: 0, 90, 217;
+	--cui-theme-positive-300: 0, 83, 199;
+	--cui-theme-positive-275: 0, 75, 181;
+	--cui-theme-positive-250: 0, 68, 163;
+	--cui-theme-positive-225: 0, 60, 145;
+	--cui-theme-positive-200: 0, 53, 126;
+	--cui-theme-positive-175: 0, 45, 109;
+	--cui-theme-positive-150: 0, 38, 91;
+	--cui-theme-positive-125: 0, 31, 75;
+	--cui-theme-positive-100: 0, 25, 59;
+	--cui-theme-positive-75: 0, 19, 45;
+	--cui-theme-positive-50: 0, 13, 31;
+	--cui-theme-positive-25: 0, 6, 15;
 	--cui-theme-positive-0: 0, 0, 0;
 
 	/** success: #6EBB00 **/
 	--cui-theme-success-1000: 255, 255, 255;
-	--cui-theme-success-975: 235, 251, 204;
-	--cui-theme-success-950: 214, 246, 160;
-	--cui-theme-success-925: 192, 240, 119;
-	--cui-theme-success-900: 169, 235, 76;
-	--cui-theme-success-875: 146, 229, 23;
-	--cui-theme-success-850: 125, 221, 21;
-	--cui-theme-success-825: 103, 214, 35;
-	--cui-theme-success-800: 78, 207, 45;
-	--cui-theme-success-775: 54, 199, 48;
-	--cui-theme-success-750: 50, 191, 44;
-	--cui-theme-success-725: 44, 183, 40;
-	--cui-theme-success-700: 40, 175, 36;
-	--cui-theme-success-675: 35, 167, 31;
-	--cui-theme-success-650: 31, 160, 27;
-	--cui-theme-success-625: 26, 153, 22;
-	--cui-theme-success-600: 21, 146, 18;
-	--cui-theme-success-575: 15, 139, 12;
-	--cui-theme-success-550: 9, 133, 6;
-	--cui-theme-success-525: 2, 127, 1;
-	--cui-theme-success-500: 6, 120, 0;
-	--cui-theme-success-475: 13, 114, 0;
-	--cui-theme-success-450: 17, 108, 0;
-	--cui-theme-success-425: 19, 102, 0;
-	--cui-theme-success-400: 22, 96, 0;
-	--cui-theme-success-375: 23, 90, 0;
-	--cui-theme-success-350: 25, 85, 0;
-	--cui-theme-success-325: 26, 79, 0;
-	--cui-theme-success-300: 26, 74, 0;
-	--cui-theme-success-275: 26, 69, 0;
-	--cui-theme-success-250: 26, 63, 0;
-	--cui-theme-success-225: 25, 58, 1;
-	--cui-theme-success-200: 24, 53, 1;
-	--cui-theme-success-175: 22, 48, 1;
-	--cui-theme-success-150: 21, 43, 1;
-	--cui-theme-success-125: 18, 37, 0;
-	--cui-theme-success-100: 17, 32, 0;
-	--cui-theme-success-75: 13, 25, 1;
-	--cui-theme-success-50: 10, 18, 1;
-	--cui-theme-success-25: 5, 10, 0;
+	--cui-theme-success-975: 246, 251, 239;
+	--cui-theme-success-950: 237, 246, 223;
+	--cui-theme-success-925: 227, 242, 206;
+	--cui-theme-success-900: 218, 238, 190;
+	--cui-theme-success-875: 208, 233, 173;
+	--cui-theme-success-850: 199, 229, 156;
+	--cui-theme-success-825: 190, 224, 140;
+	--cui-theme-success-800: 181, 220, 125;
+	--cui-theme-success-775: 173, 216, 110;
+	--cui-theme-success-750: 165, 213, 96;
+	--cui-theme-success-725: 157, 209, 82;
+	--cui-theme-success-700: 149, 205, 69;
+	--cui-theme-success-675: 141, 202, 55;
+	--cui-theme-success-650: 133, 198, 41;
+	--cui-theme-success-625: 125, 194, 27;
+	--cui-theme-success-600: 117, 190, 12;
+	--cui-theme-success-575: 109, 186, 0;
+	--cui-theme-success-550: 106, 180, 0;
+	--cui-theme-success-525: 102, 174, 0;
+	--cui-theme-success-500: 99, 168, 0;
+	--cui-theme-success-475: 95, 161, 0;
+	--cui-theme-success-450: 90, 154, 0;
+	--cui-theme-success-425: 86, 146, 0;
+	--cui-theme-success-400: 81, 137, 0;
+	--cui-theme-success-375: 76, 129, 0;
+	--cui-theme-success-350: 70, 120, 0;
+	--cui-theme-success-325: 65, 111, 0;
+	--cui-theme-success-300: 60, 101, 0;
+	--cui-theme-success-275: 54, 92, 0;
+	--cui-theme-success-250: 49, 82, 0;
+	--cui-theme-success-225: 43, 73, 0;
+	--cui-theme-success-200: 37, 64, 0;
+	--cui-theme-success-175: 32, 54, 0;
+	--cui-theme-success-150: 27, 45, 0;
+	--cui-theme-success-125: 22, 37, 0;
+	--cui-theme-success-100: 17, 29, 0;
+	--cui-theme-success-75: 13, 22, 0;
+	--cui-theme-success-50: 8, 14, 0;
+	--cui-theme-success-25: 4, 7, 0;
 	--cui-theme-success-0: 0, 0, 0;
 
-	/** warn: #EC9117 **/
+	/** warn: #FF6600 **/
 	--cui-theme-warn-1000: 255, 255, 255;
-	--cui-theme-warn-975: 255, 243, 225;
-	--cui-theme-warn-950: 255, 231, 201;
-	--cui-theme-warn-925: 255, 219, 178;
-	--cui-theme-warn-900: 255, 207, 158;
-	--cui-theme-warn-875: 255, 194, 141;
-	--cui-theme-warn-850: 255, 182, 125;
-	--cui-theme-warn-825: 255, 170, 110;
-	--cui-theme-warn-800: 255, 157, 95;
-	--cui-theme-warn-775: 255, 145, 80;
-	--cui-theme-warn-750: 254, 132, 63;
-	--cui-theme-warn-725: 247, 124, 56;
-	--cui-theme-warn-700: 239, 116, 49;
-	--cui-theme-warn-675: 232, 108, 43;
-	--cui-theme-warn-650: 226, 100, 37;
-	--cui-theme-warn-625: 219, 93, 30;
-	--cui-theme-warn-600: 212, 86, 24;
-	--cui-theme-warn-575: 205, 79, 17;
-	--cui-theme-warn-550: 200, 71, 8;
-	--cui-theme-warn-525: 194, 64, 0;
-	--cui-theme-warn-500: 184, 61, 0;
-	--cui-theme-warn-475: 174, 58, 0;
-	--cui-theme-warn-450: 165, 56, 0;
-	--cui-theme-warn-425: 155, 54, 0;
-	--cui-theme-warn-400: 146, 52, 0;
-	--cui-theme-warn-375: 138, 49, 1;
-	--cui-theme-warn-350: 129, 47, 1;
-	--cui-theme-warn-325: 120, 45, 1;
-	--cui-theme-warn-300: 112, 42, 1;
-	--cui-theme-warn-275: 104, 40, 0;
-	--cui-theme-warn-250: 95, 38, 0;
-	--cui-theme-warn-225: 86, 37, 0;
-	--cui-theme-warn-200: 76, 35, 0;
-	--cui-theme-warn-175: 67, 33, 0;
-	--cui-theme-warn-150: 59, 30, 0;
-	--cui-theme-warn-125: 52, 26, 1;
-	--cui-theme-warn-100: 45, 22, 1;
-	--cui-theme-warn-75: 37, 17, 1;
-	--cui-theme-warn-50: 27, 13, 0;
-	--cui-theme-warn-25: 15, 6, 0;
+	--cui-theme-warn-975: 255, 248, 243;
+	--cui-theme-warn-950: 255, 240, 231;
+	--cui-theme-warn-925: 255, 233, 218;
+	--cui-theme-warn-900: 255, 225, 205;
+	--cui-theme-warn-875: 255, 217, 192;
+	--cui-theme-warn-850: 255, 210, 179;
+	--cui-theme-warn-825: 255, 202, 167;
+	--cui-theme-warn-800: 255, 195, 155;
+	--cui-theme-warn-775: 255, 188, 144;
+	--cui-theme-warn-750: 255, 182, 133;
+	--cui-theme-warn-725: 255, 175, 122;
+	--cui-theme-warn-700: 255, 169, 111;
+	--cui-theme-warn-675: 255, 162, 100;
+	--cui-theme-warn-650: 255, 155, 89;
+	--cui-theme-warn-625: 255, 148, 77;
+	--cui-theme-warn-600: 255, 141, 65;
+	--cui-theme-warn-575: 255, 133, 51;
+	--cui-theme-warn-550: 255, 124, 36;
+	--cui-theme-warn-525: 255, 113, 19;
+	--cui-theme-warn-500: 254, 102, 0;
+	--cui-theme-warn-475: 244, 98, 0;
+	--cui-theme-warn-450: 233, 93, 0;
+	--cui-theme-warn-425: 221, 88, 0;
+	--cui-theme-warn-400: 209, 83, 0;
+	--cui-theme-warn-375: 196, 78, 0;
+	--cui-theme-warn-350: 182, 73, 0;
+	--cui-theme-warn-325: 168, 67, 0;
+	--cui-theme-warn-300: 154, 62, 0;
+	--cui-theme-warn-275: 140, 56, 0;
+	--cui-theme-warn-250: 126, 50, 0;
+	--cui-theme-warn-225: 112, 45, 0;
+	--cui-theme-warn-200: 98, 39, 0;
+	--cui-theme-warn-175: 84, 33, 0;
+	--cui-theme-warn-150: 70, 28, 0;
+	--cui-theme-warn-125: 57, 23, 0;
+	--cui-theme-warn-100: 45, 18, 0;
+	--cui-theme-warn-75: 34, 14, 0;
+	--cui-theme-warn-50: 23, 9, 0;
+	--cui-theme-warn-25: 11, 4, 0;
 	--cui-theme-warn-0: 0, 0, 0;
 
-	/** danger: #FF4827 **/
+	/** danger: #FF0000 **/
 	--cui-theme-danger-1000: 255, 255, 255;
-	--cui-theme-danger-975: 255, 242, 238;
-	--cui-theme-danger-950: 255, 229, 223;
-	--cui-theme-danger-925: 255, 216, 210;
-	--cui-theme-danger-900: 255, 203, 197;
-	--cui-theme-danger-875: 255, 191, 185;
-	--cui-theme-danger-850: 255, 178, 175;
-	--cui-theme-danger-825: 255, 165, 165;
-	--cui-theme-danger-800: 255, 152, 156;
-	--cui-theme-danger-775: 255, 139, 147;
-	--cui-theme-danger-750: 255, 126, 138;
-	--cui-theme-danger-725: 255, 112, 131;
-	--cui-theme-danger-700: 255, 96, 123;
-	--cui-theme-danger-675: 255, 81, 107;
-	--cui-theme-danger-650: 255, 63, 84;
-	--cui-theme-danger-625: 255, 39, 56;
-	--cui-theme-danger-600: 252, 0, 27;
-	--cui-theme-danger-575: 240, 0, 26;
-	--cui-theme-danger-550: 229, 0, 26;
-	--cui-theme-danger-525: 219, 0, 26;
-	--cui-theme-danger-500: 208, 0, 25;
-	--cui-theme-danger-475: 198, 0, 25;
-	--cui-theme-danger-450: 188, 0, 25;
-	--cui-theme-danger-425: 179, 0, 24;
-	--cui-theme-danger-400: 169, 0, 24;
-	--cui-theme-danger-375: 160, 0, 24;
-	--cui-theme-danger-350: 151, 0, 21;
-	--cui-theme-danger-325: 143, 0, 18;
-	--cui-theme-danger-300: 134, 0, 15;
-	--cui-theme-danger-275: 126, 0, 12;
-	--cui-theme-danger-250: 117, 0, 9;
-	--cui-theme-danger-225: 109, 0, 6;
-	--cui-theme-danger-200: 101, 0, 2;
-	--cui-theme-danger-175: 92, 1, 1;
-	--cui-theme-danger-150: 81, 5, 2;
-	--cui-theme-danger-125: 70, 8, 4;
-	--cui-theme-danger-100: 58, 9, 5;
-	--cui-theme-danger-75: 46, 10, 6;
-	--cui-theme-danger-50: 33, 8, 6;
-	--cui-theme-danger-25: 18, 5, 4;
+	--cui-theme-danger-975: 255, 247, 247;
+	--cui-theme-danger-950: 255, 240, 238;
+	--cui-theme-danger-925: 255, 232, 230;
+	--cui-theme-danger-900: 255, 223, 221;
+	--cui-theme-danger-875: 255, 215, 212;
+	--cui-theme-danger-850: 255, 207, 204;
+	--cui-theme-danger-825: 255, 200, 195;
+	--cui-theme-danger-800: 255, 192, 187;
+	--cui-theme-danger-775: 255, 185, 180;
+	--cui-theme-danger-750: 255, 178, 173;
+	--cui-theme-danger-725: 255, 172, 166;
+	--cui-theme-danger-700: 255, 165, 159;
+	--cui-theme-danger-675: 255, 158, 152;
+	--cui-theme-danger-650: 255, 151, 145;
+	--cui-theme-danger-625: 255, 144, 137;
+	--cui-theme-danger-600: 255, 137, 130;
+	--cui-theme-danger-575: 255, 128, 121;
+	--cui-theme-danger-550: 255, 119, 112;
+	--cui-theme-danger-525: 255, 109, 101;
+	--cui-theme-danger-500: 255, 97, 89;
+	--cui-theme-danger-475: 255, 83, 74;
+	--cui-theme-danger-450: 255, 64, 55;
+	--cui-theme-danger-425: 255, 33, 24;
+	--cui-theme-danger-400: 246, 10, 0;
+	--cui-theme-danger-375: 231, 8, 0;
+	--cui-theme-danger-350: 215, 8, 0;
+	--cui-theme-danger-325: 200, 6, 0;
+	--cui-theme-danger-300: 184, 5, 0;
+	--cui-theme-danger-275: 168, 5, 0;
+	--cui-theme-danger-250: 152, 4, 0;
+	--cui-theme-danger-225: 136, 3, 0;
+	--cui-theme-danger-200: 120, 2, 0;
+	--cui-theme-danger-175: 104, 2, 0;
+	--cui-theme-danger-150: 89, 1, 0;
+	--cui-theme-danger-125: 74, 1, 0;
+	--cui-theme-danger-100: 61, 1, 0;
+	--cui-theme-danger-75: 48, 0, 0;
+	--cui-theme-danger-50: 36, 0, 0;
+	--cui-theme-danger-25: 22, 0, 0;
 	--cui-theme-danger-0: 0, 0, 0;
 
 	/** default: #999999 **/
 	--cui-theme-default-1000: 255, 255, 255;
-	--cui-theme-default-975: 245, 245, 245;
-	--cui-theme-default-950: 234, 234, 234;
-	--cui-theme-default-925: 225, 225, 225;
-	--cui-theme-default-900: 215, 215, 215;
-	--cui-theme-default-875: 206, 206, 206;
-	--cui-theme-default-850: 198, 198, 198;
-	--cui-theme-default-825: 189, 189, 189;
-	--cui-theme-default-800: 181, 181, 181;
-	--cui-theme-default-775: 173, 173, 173;
-	--cui-theme-default-750: 166, 166, 166;
-	--cui-theme-default-725: 158, 158, 158;
-	--cui-theme-default-700: 151, 151, 151;
-	--cui-theme-default-675: 145, 145, 145;
-	--cui-theme-default-650: 138, 138, 138;
-	--cui-theme-default-625: 132, 132, 132;
-	--cui-theme-default-600: 126, 126, 126;
-	--cui-theme-default-575: 120, 120, 120;
-	--cui-theme-default-550: 114, 114, 114;
-	--cui-theme-default-525: 108, 108, 108;
-	--cui-theme-default-500: 103, 103, 103;
-	--cui-theme-default-475: 98, 98, 98;
-	--cui-theme-default-450: 92, 92, 92;
-	--cui-theme-default-425: 87, 87, 87;
-	--cui-theme-default-400: 82, 82, 82;
-	--cui-theme-default-375: 78, 78, 78;
-	--cui-theme-default-350: 73, 73, 73;
-	--cui-theme-default-325: 68, 68, 68;
-	--cui-theme-default-300: 64, 64, 64;
-	--cui-theme-default-275: 59, 59, 59;
-	--cui-theme-default-250: 55, 55, 55;
-	--cui-theme-default-225: 51, 51, 51;
-	--cui-theme-default-200: 46, 46, 46;
-	--cui-theme-default-175: 42, 42, 42;
-	--cui-theme-default-150: 37, 37, 37;
-	--cui-theme-default-125: 32, 32, 32;
-	--cui-theme-default-100: 27, 27, 27;
-	--cui-theme-default-75: 22, 22, 22;
-	--cui-theme-default-50: 16, 16, 16;
-	--cui-theme-default-25: 8, 8, 8;
+	--cui-theme-default-975: 249, 249, 249;
+	--cui-theme-default-950: 243, 243, 243;
+	--cui-theme-default-925: 237, 237, 237;
+	--cui-theme-default-900: 230, 230, 230;
+	--cui-theme-default-875: 224, 224, 224;
+	--cui-theme-default-850: 218, 218, 218;
+	--cui-theme-default-825: 213, 213, 213;
+	--cui-theme-default-800: 207, 207, 207;
+	--cui-theme-default-775: 202, 202, 202;
+	--cui-theme-default-750: 198, 198, 198;
+	--cui-theme-default-725: 193, 193, 193;
+	--cui-theme-default-700: 189, 189, 189;
+	--cui-theme-default-675: 184, 184, 184;
+	--cui-theme-default-650: 180, 180, 180;
+	--cui-theme-default-625: 175, 175, 175;
+	--cui-theme-default-600: 171, 171, 171;
+	--cui-theme-default-575: 166, 166, 166;
+	--cui-theme-default-550: 161, 161, 161;
+	--cui-theme-default-525: 156, 156, 156;
+	--cui-theme-default-500: 150, 150, 150;
+	--cui-theme-default-475: 144, 144, 144;
+	--cui-theme-default-450: 137, 137, 137;
+	--cui-theme-default-425: 130, 130, 130;
+	--cui-theme-default-400: 123, 123, 123;
+	--cui-theme-default-375: 115, 115, 115;
+	--cui-theme-default-350: 107, 107, 107;
+	--cui-theme-default-325: 99, 99, 99;
+	--cui-theme-default-300: 90, 90, 90;
+	--cui-theme-default-275: 82, 82, 82;
+	--cui-theme-default-250: 73, 73, 73;
+	--cui-theme-default-225: 65, 65, 65;
+	--cui-theme-default-200: 56, 56, 56;
+	--cui-theme-default-175: 48, 48, 48;
+	--cui-theme-default-150: 40, 40, 40;
+	--cui-theme-default-125: 33, 33, 33;
+	--cui-theme-default-100: 25, 25, 25;
+	--cui-theme-default-75: 19, 19, 19;
+	--cui-theme-default-50: 12, 12, 12;
+	--cui-theme-default-25: 6, 6, 6;
 	--cui-theme-default-0: 0, 0, 0;
 
 	/* Content */
@@ -432,7 +432,7 @@
 }
 
 /*** Color themes ***/
-/** #15009C **/
+/** #000067 **/
 .theme-primary,
 .theme-primary\:hover:hover,
 .theme-primary\:active:active,
@@ -738,7 +738,7 @@
 	--cui-controls-0: var(--cui-theme-tertiary-0);
 }
 
-/** #4390FF **/
+/** #006AFF **/
 .theme-positive,
 .theme-positive\:hover:hover,
 .theme-positive\:active:active,
@@ -942,7 +942,7 @@
 	--cui-controls-0: var(--cui-theme-success-0);
 }
 
-/** #EC9117 **/
+/** #FF6600 **/
 .theme-warn,
 .theme-warn\:hover:hover,
 .theme-warn\:active:active,
@@ -1044,7 +1044,7 @@
 	--cui-controls-0: var(--cui-theme-warn-0);
 }
 
-/** #FF4827 **/
+/** #FF0000 **/
 .theme-danger,
 .theme-danger\:hover:hover,
 .theme-danger\:active:active,
@@ -1292,6 +1292,21 @@
 	--cui-filled-control-background-color--pressed: inherit;
 	--cui-filled-control-border-color--pressed: inherit;
 
+	/* FilledPrimary */
+	--cui-filled-primary-control-color: inherit;
+	--cui-filled-primary-control-background-color: inherit;
+	--cui-filled-primary-control-border-color: inherit;
+
+	/* FilledPrimary:highlighted */
+	--cui-filled-primary-control-color--highlighted: inherit;
+	--cui-filled-primary-control-background-color--highlighted: inherit;
+	--cui-filled-primary-control-border-color--highlighted: inherit;
+
+	/* FilledPrimary:pressed */
+	--cui-filled-primary-control-color--pressed: inherit;
+	--cui-filled-primary-control-background-color--pressed: inherit;
+	--cui-filled-primary-control-border-color--pressed: inherit;
+
 	/* Toned */
 	--cui-toned-control-color: inherit;
 	--cui-toned-control-background-color: inherit;
@@ -1339,7 +1354,7 @@
 	--cui-opacity--medium: 0.500;
 	--cui-opacity--low: 0.300;
 	--cui-opacity--lower: 0.125;
-	--cui-opacity--control-background-color: 0.000;
+	--cui-opacity--control-background-color: 0.250;
 	--cui-opacity--control-background-color--highlighted: 0.750;
 	--cui-opacity--filled-control-background-color--pressed: 0.175;
 	--cui-opacity--toned-control-background-color: 0.500;
@@ -1353,13 +1368,131 @@
 	--cui-opacity--medium: 0.500;
 	--cui-opacity--low: 0.300;
 	--cui-opacity--lower: 0.125;
-	--cui-opacity--control-background-color: 0.000;
+	--cui-opacity--control-background-color: 0.250;
 	--cui-opacity--control-background-color--highlighted: 0.750;
 	--cui-opacity--filled-control-background-color--pressed: 0.750;
-	--cui-opacity--toned-control-background-color: 0.750;
+	--cui-opacity--toned-control-background-color: 0.250;
 }
 .scheme-light-below, .scheme-light-below *:not([class*="scheme-"]),
 .scheme-system-below, .scheme-system-below *:not([class*="scheme-"]) {
+	/* Content */
+	--cui-background-color: rgb(var(--cui-content-925));
+	--cui-background-color--above: rgb(var(--cui-content-950));
+	--cui-background-color--below: rgb(var(--cui-content-900));
+	--cui-color: rgba(var(--cui-content-50), 0.750);
+	--cui-color--strong: rgb(var(--cui-content-50));
+	--cui-color--high: rgba(var(--cui-content-50), 0.750);
+	--cui-color--medium: rgba(var(--cui-content-50), 0.500);
+	--cui-color--low: rgba(var(--cui-content-50), 0.300);
+	--cui-color--lower: rgba(var(--cui-content-50), 0.125);
+
+	/* Control – 925 : 350*/
+	--cui-control-color: rgb(var(--cui-controls-350));
+	--cui-control-background-color: rgba(var(--cui-controls-925), 0.250);
+	--cui-control-border-color: rgb(var(--cui-controls-425));
+
+	/* Content:highlighted – 925 : 350 */
+	--cui-color--highlighted: rgb(var(--cui-content-350));
+	--cui-background-color--highlighted: rgba(var(--cui-content-1000), 0.750);
+	--cui-border-color--highlighted: rgb(var(--cui-content-350));
+	/* Control:highlighted – 925 : 350 */
+	--cui-control-color--highlighted: rgb(var(--cui-controls-350));
+	--cui-control-background-color--highlighted: rgba(var(--cui-controls-1000), 0.750);
+	--cui-control-border-color--highlighted: rgb(var(--cui-controls-350));
+
+	/* Content:pressed — 925 : 275 */
+	--cui-color--pressed: rgb(var(--cui-content-475));
+	--cui-background-color--pressed: rgba(var(--cui-content-125), 0.175);
+	--cui-border-color--pressed: rgb(var(--cui-content-475));
+	/* Control:pressed — 925 : 275 */
+	--cui-control-color--pressed: rgb(var(--cui-controls-475));
+	--cui-control-background-color--pressed: rgba(var(--cui-controls-125), 0.175);
+	--cui-control-border-color--pressed: rgb(var(--cui-controls-475));
+
+	/* FilledContent — 875 : rgb(var(--cui-content-300)) */
+	--cui-filled-color: rgb(var(--cui-content-300));
+	--cui-filled-background-color: rgb(var(--cui-content-875));
+	--cui-filled-border-color: rgb(var(--cui-content-300));
+	/* FilledControl — 875 : rgb(var(--cui-controls-300)) */
+	--cui-filled-control-color: rgb(var(--cui-controls-300));
+	--cui-filled-control-background-color: rgb(var(--cui-controls-875));
+	--cui-filled-control-border-color: rgb(var(--cui-controls-300));
+
+	/* FilledContent:highlighted – 1000 : 350 */
+	--cui-filled-color--highlighted: rgb(var(--cui-content-350));
+	--cui-filled-background-color--highlighted: rgb(var(--cui-content-1000));
+	--cui-filled-border-color--highlighted: rgb(var(--cui-content-350));
+	/* FilledControl:highlighted – 1000 : 350 */
+	--cui-filled-control-color--highlighted: rgb(var(--cui-controls-350));
+	--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-1000));
+	--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-350));
+
+	/* FilledContent:pressed – 125 alpha : 475 */
+	--cui-filled-color--pressed: rgb(var(--cui-content-475));
+	--cui-filled-background-color--pressed: rgba(var(--cui-content-125), 0.175);
+	--cui-filled-border-color--pressed: rgb(var(--cui-content-475));
+	/* FilledControl:pressed – 125 alpha : 475 */
+	--cui-filled-control-color--pressed: rgb(var(--cui-controls-475));
+	--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-125), 0.175);
+	--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-475));
+
+	/* FilledPrimaryContent — 325 : rgb(var(--cui-content-300)) */
+	--cui-filled-primary-color: rgb(var(--cui-content-925));
+	--cui-filled-primary-background-color: rgb(var(--cui-content-325));
+	--cui-filled-primary-border-color: rgb(var(--cui-content-925));
+	/* FilledPrimaryControl — 325 : rgb(var(--cui-controls-300)) */
+	--cui-filled-primary-control-color: rgb(var(--cui-controls-925));
+	--cui-filled-primary-control-background-color: rgb(var(--cui-controls-325));
+	--cui-filled-primary-control-border-color: rgb(var(--cui-controls-925));
+
+	/* FilledPrimaryContent:highlighted – 425 : 1300 */
+	--cui-filled-primary-color--highlighted: rgb(var(--cui-content-1000));
+	--cui-filled-primary-background-color--highlighted: rgb(var(--cui-content-425));
+	--cui-filled-primary-border-color--highlighted: rgb(var(--cui-content-1000));
+	/* FilledPrimaryControl:highlighted – 425 : 1300 */
+	--cui-filled-primary-control-color--highlighted: rgb(var(--cui-controls-1000));
+	--cui-filled-primary-control-background-color--highlighted: rgb(var(--cui-controls-425));
+	--cui-filled-primary-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+
+	/* FilledPrimaryContent:pressed – 325 alpha : 725 */
+	--cui-filled-primary-color--pressed: rgb(var(--cui-content-725));
+	--cui-filled-primary-background-color--pressed: rgb(var(--cui-content-325));
+	--cui-filled-primary-border-color--pressed: rgb(var(--cui-content-725));
+	/* FilledPrimaryControl:pressed – 325 alpha : 725 */
+	--cui-filled-primary-control-color--pressed: rgb(var(--cui-controls-725));
+	--cui-filled-primary-control-background-color--pressed: rgb(var(--cui-controls-325));
+	--cui-filled-primary-control-border-color--pressed: rgb(var(--cui-controls-725));
+
+	/* TonedContent — 800 alpha : 225 */
+	--cui-toned-color: rgb(var(--cui-content-225));
+	--cui-toned-background-color: rgba(var(--cui-content-800), 0.500);
+	--cui-toned-border-color: rgb(var(--cui-content-225));
+	/* TonedControl — 800 alpha : 225 */
+	--cui-toned-control-color: rgb(var(--cui-controls-225));
+	--cui-toned-control-background-color: rgba(var(--cui-controls-800), 0.500);
+	--cui-toned-control-border-color: rgb(var(--cui-controls-225));
+
+	/* TonedContent:highlighted = FilledControl:highlighted */
+	--cui-toned-color--highlighted: rgb(var(--cui-content-1000));
+	--cui-toned-background-color--highlighted: rgb(var(--cui-content-425));
+	--cui-toned-border-color--highlighted: rgb(var(--cui-content-350));
+	/* TonedControl:highlighted = FilledControl:highlighted */
+	--cui-toned-control-color--highlighted: rgb(var(--cui-controls-425));
+	--cui-toned-control-background-color--highlighted: rgba(var(--cui-controls-1000), 0.750);
+	--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-350));
+
+	/* TonedContent:pressed = FilledControl:pressed */
+	--cui-toned-color--pressed: rgb(var(--cui-content-475));
+	--cui-toned-background-color--pressed: rgba(var(--cui-content-125), 0.175);
+	--cui-toned-border-color--pressed: rgb(var(--cui-content-475));
+	/* TonedControl:pressed = FilledControl:pressed */
+	--cui-toned-control-color--pressed: rgb(var(--cui-controls-475));
+	--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-125), 0.175);
+	--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-475));
+}
+:root, :root *:not([class*="scheme-"]),
+.scheme-light, .scheme-light *:not([class*="scheme-"]),
+.scheme-system, .scheme-system *:not([class*="scheme-"]) {
 	/* Content */
 	--cui-background-color: rgb(var(--cui-content-950));
 	--cui-background-color--above: rgb(var(--cui-content-975));
@@ -1371,54 +1504,112 @@
 	--cui-color--low: rgba(var(--cui-content-75), 0.300);
 	--cui-color--lower: rgba(var(--cui-content-75), 0.125);
 
-	/* Control – 950 : 475*/
-	--cui-control-color: rgb(var(--cui-controls-475));
-	--cui-control-background-color: rgba(var(--cui-controls-950), 0.00);
-	--cui-control-border-color: rgb(var(--cui-controls-475));
+	/* Control – 950 : 375*/
+	--cui-control-color: rgb(var(--cui-controls-375));
+	--cui-control-background-color: rgba(var(--cui-controls-950), 0.250);
+	--cui-control-border-color: rgb(var(--cui-controls-450));
 
-	/* Control:highlighted – 950 : 575 */
-	--cui-control-color--highlighted: rgb(var(--cui-controls-575));
+	/* Content:highlighted – 950 : 375 */
+	--cui-color--highlighted: rgb(var(--cui-content-375));
+	--cui-background-color--highlighted: rgba(var(--cui-content-1000), 0.750);
+	--cui-border-color--highlighted: rgb(var(--cui-content-375));
+	/* Control:highlighted – 950 : 375 */
+	--cui-control-color--highlighted: rgb(var(--cui-controls-375));
 	--cui-control-background-color--highlighted: rgba(var(--cui-controls-1000), 0.750);
-	--cui-control-border-color--highlighted: rgb(var(--cui-controls-575));
+	--cui-control-border-color--highlighted: rgb(var(--cui-controls-375));
 
-	/* Control:pressed — 950 : 475 */
-	--cui-control-color--pressed: rgb(var(--cui-controls-550));
-	--cui-control-background-color--pressed: rgba(var(--cui-controls-1000), 0.175);
-	--cui-control-border-color--pressed: rgb(var(--cui-controls-750));
+	/* Content:pressed — 950 : 300 */
+	--cui-color--pressed: rgb(var(--cui-content-500));
+	--cui-background-color--pressed: rgba(var(--cui-content-150), 0.175);
+	--cui-border-color--pressed: rgb(var(--cui-content-500));
+	/* Control:pressed — 950 : 300 */
+	--cui-control-color--pressed: rgb(var(--cui-controls-500));
+	--cui-control-background-color--pressed: rgba(var(--cui-controls-150), 0.175);
+	--cui-control-border-color--pressed: rgb(var(--cui-controls-500));
 
-	/* Filled — 1050 : rgb(var(--cui-controls-500)) */
-	--cui-filled-control-color: rgb(var(--cui-controls-500));
-	--cui-filled-control-background-color: rgb(var(--cui-controls-1000));
-	--cui-filled-control-border-color: rgb(var(--cui-controls-500));
+	/* FilledContent — 900 : rgb(var(--cui-content-325)) */
+	--cui-filled-color: rgb(var(--cui-content-325));
+	--cui-filled-background-color: rgb(var(--cui-content-900));
+	--cui-filled-border-color: rgb(var(--cui-content-325));
+	/* FilledControl — 900 : rgb(var(--cui-controls-325)) */
+	--cui-filled-control-color: rgb(var(--cui-controls-325));
+	--cui-filled-control-background-color: rgb(var(--cui-controls-900));
+	--cui-filled-control-border-color: rgb(var(--cui-controls-325));
 
-	/* Filled:highlighted – 1150 : 600 */
-	--cui-filled-control-color--highlighted: rgb(var(--cui-controls-600));
+	/* FilledContent:highlighted – 1025 : 375 */
+	--cui-filled-color--highlighted: rgb(var(--cui-content-375));
+	--cui-filled-background-color--highlighted: rgb(var(--cui-content-1000));
+	--cui-filled-border-color--highlighted: rgb(var(--cui-content-375));
+	/* FilledControl:highlighted – 1025 : 375 */
+	--cui-filled-control-color--highlighted: rgb(var(--cui-controls-375));
 	--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-1000));
-	--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-600));
+	--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-375));
 
-	/* Filled:pressed – 1050 alpha : 550 */
-	--cui-filled-control-color--pressed: rgb(var(--cui-controls-550));
-	--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-1000), 0.175);
-	--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-750));
+	/* FilledContent:pressed – 150 alpha : 500 */
+	--cui-filled-color--pressed: rgb(var(--cui-content-500));
+	--cui-filled-background-color--pressed: rgba(var(--cui-content-150), 0.175);
+	--cui-filled-border-color--pressed: rgb(var(--cui-content-500));
+	/* FilledControl:pressed – 150 alpha : 500 */
+	--cui-filled-control-color--pressed: rgb(var(--cui-controls-500));
+	--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-150), 0.175);
+	--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-500));
 
-	/* Toned — 800 alpha : 450 */
-	--cui-toned-control-color: rgb(var(--cui-controls-450));
-	--cui-toned-control-background-color: rgba(var(--cui-controls-800), 0.500);
-	--cui-toned-control-border-color: rgb(var(--cui-controls-450));
+	/* FilledPrimaryContent — 350 : rgb(var(--cui-content-325)) */
+	--cui-filled-primary-color: rgb(var(--cui-content-950));
+	--cui-filled-primary-background-color: rgb(var(--cui-content-350));
+	--cui-filled-primary-border-color: rgb(var(--cui-content-950));
+	/* FilledPrimaryControl — 350 : rgb(var(--cui-controls-325)) */
+	--cui-filled-primary-control-color: rgb(var(--cui-controls-950));
+	--cui-filled-primary-control-background-color: rgb(var(--cui-controls-350));
+	--cui-filled-primary-control-border-color: rgb(var(--cui-controls-950));
 
-	/* Toned:highlighted = Filled:highlighted */
-	--cui-toned-control-color--highlighted: rgb(var(--cui-controls-600));
-	--cui-toned-control-background-color--highlighted: rgb(var(--cui-controls-1000));
-	--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-600));
+	/* FilledPrimaryContent:highlighted – 450 : 1325 */
+	--cui-filled-primary-color--highlighted: rgb(var(--cui-content-1000));
+	--cui-filled-primary-background-color--highlighted: rgb(var(--cui-content-450));
+	--cui-filled-primary-border-color--highlighted: rgb(var(--cui-content-1000));
+	/* FilledPrimaryControl:highlighted – 450 : 1325 */
+	--cui-filled-primary-control-color--highlighted: rgb(var(--cui-controls-1000));
+	--cui-filled-primary-control-background-color--highlighted: rgb(var(--cui-controls-450));
+	--cui-filled-primary-control-border-color--highlighted: rgb(var(--cui-controls-1000));
 
-	/* Toned:pressed = Filled:pressed */
-	--cui-toned-control-color--pressed: rgb(var(--cui-controls-550));
-	--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-1000), 0.175);
-	--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-750));
+	/* FilledPrimaryContent:pressed – 350 alpha : 750 */
+	--cui-filled-primary-color--pressed: rgb(var(--cui-content-750));
+	--cui-filled-primary-background-color--pressed: rgb(var(--cui-content-350));
+	--cui-filled-primary-border-color--pressed: rgb(var(--cui-content-750));
+	/* FilledPrimaryControl:pressed – 350 alpha : 750 */
+	--cui-filled-primary-control-color--pressed: rgb(var(--cui-controls-750));
+	--cui-filled-primary-control-background-color--pressed: rgb(var(--cui-controls-350));
+	--cui-filled-primary-control-border-color--pressed: rgb(var(--cui-controls-750));
+
+	/* TonedContent — 825 alpha : 250 */
+	--cui-toned-color: rgb(var(--cui-content-250));
+	--cui-toned-background-color: rgba(var(--cui-content-825), 0.500);
+	--cui-toned-border-color: rgb(var(--cui-content-250));
+	/* TonedControl — 825 alpha : 250 */
+	--cui-toned-control-color: rgb(var(--cui-controls-250));
+	--cui-toned-control-background-color: rgba(var(--cui-controls-825), 0.500);
+	--cui-toned-control-border-color: rgb(var(--cui-controls-250));
+
+	/* TonedContent:highlighted = FilledControl:highlighted */
+	--cui-toned-color--highlighted: rgb(var(--cui-content-1000));
+	--cui-toned-background-color--highlighted: rgb(var(--cui-content-450));
+	--cui-toned-border-color--highlighted: rgb(var(--cui-content-375));
+	/* TonedControl:highlighted = FilledControl:highlighted */
+	--cui-toned-control-color--highlighted: rgb(var(--cui-controls-450));
+	--cui-toned-control-background-color--highlighted: rgba(var(--cui-controls-1000), 0.750);
+	--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-375));
+
+	/* TonedContent:pressed = FilledControl:pressed */
+	--cui-toned-color--pressed: rgb(var(--cui-content-500));
+	--cui-toned-background-color--pressed: rgba(var(--cui-content-150), 0.175);
+	--cui-toned-border-color--pressed: rgb(var(--cui-content-500));
+	/* TonedControl:pressed = FilledControl:pressed */
+	--cui-toned-control-color--pressed: rgb(var(--cui-controls-500));
+	--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-150), 0.175);
+	--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-500));
 }
-:root, :root *:not([class*="scheme-"]),
-.scheme-light, .scheme-light *:not([class*="scheme-"]),
-.scheme-system, .scheme-system *:not([class*="scheme-"]) {
+.scheme-light-above, .scheme-light-above *:not([class*="scheme-"]),
+.scheme-system-above, .scheme-system-above *:not([class*="scheme-"]) {
 	/* Content */
 	--cui-background-color: rgb(var(--cui-content-975));
 	--cui-background-color--above: rgb(var(--cui-content-1000));
@@ -1430,279 +1621,457 @@
 	--cui-color--low: rgba(var(--cui-content-100), 0.300);
 	--cui-color--lower: rgba(var(--cui-content-100), 0.125);
 
-	/* Control – 975 : 500*/
-	--cui-control-color: rgb(var(--cui-controls-500));
-	--cui-control-background-color: rgba(var(--cui-controls-975), 0.00);
-	--cui-control-border-color: rgb(var(--cui-controls-500));
+	/* Control – 975 : 400*/
+	--cui-control-color: rgb(var(--cui-controls-400));
+	--cui-control-background-color: rgba(var(--cui-controls-975), 0.250);
+	--cui-control-border-color: rgb(var(--cui-controls-475));
 
-	/* Control:highlighted – 975 : 600 */
-	--cui-control-color--highlighted: rgb(var(--cui-controls-600));
+	/* Content:highlighted – 975 : 400 */
+	--cui-color--highlighted: rgb(var(--cui-content-400));
+	--cui-background-color--highlighted: rgba(var(--cui-content-1000), 0.750);
+	--cui-border-color--highlighted: rgb(var(--cui-content-400));
+	/* Control:highlighted – 975 : 400 */
+	--cui-control-color--highlighted: rgb(var(--cui-controls-400));
 	--cui-control-background-color--highlighted: rgba(var(--cui-controls-1000), 0.750);
-	--cui-control-border-color--highlighted: rgb(var(--cui-controls-600));
+	--cui-control-border-color--highlighted: rgb(var(--cui-controls-400));
 
-	/* Control:pressed — 975 : 500 */
-	--cui-control-color--pressed: rgb(var(--cui-controls-575));
-	--cui-control-background-color--pressed: rgba(var(--cui-controls-1000), 0.175);
-	--cui-control-border-color--pressed: rgb(var(--cui-controls-775));
+	/* Content:pressed — 975 : 325 */
+	--cui-color--pressed: rgb(var(--cui-content-525));
+	--cui-background-color--pressed: rgba(var(--cui-content-175), 0.175);
+	--cui-border-color--pressed: rgb(var(--cui-content-525));
+	/* Control:pressed — 975 : 325 */
+	--cui-control-color--pressed: rgb(var(--cui-controls-525));
+	--cui-control-background-color--pressed: rgba(var(--cui-controls-175), 0.175);
+	--cui-control-border-color--pressed: rgb(var(--cui-controls-525));
 
-	/* Filled — 1075 : rgb(var(--cui-controls-525)) */
-	--cui-filled-control-color: rgb(var(--cui-controls-525));
-	--cui-filled-control-background-color: rgb(var(--cui-controls-1000));
-	--cui-filled-control-border-color: rgb(var(--cui-controls-525));
+	/* FilledContent — 925 : rgb(var(--cui-content-350)) */
+	--cui-filled-color: rgb(var(--cui-content-350));
+	--cui-filled-background-color: rgb(var(--cui-content-925));
+	--cui-filled-border-color: rgb(var(--cui-content-350));
+	/* FilledControl — 925 : rgb(var(--cui-controls-350)) */
+	--cui-filled-control-color: rgb(var(--cui-controls-350));
+	--cui-filled-control-background-color: rgb(var(--cui-controls-925));
+	--cui-filled-control-border-color: rgb(var(--cui-controls-350));
 
-	/* Filled:highlighted – 1175 : 625 */
-	--cui-filled-control-color--highlighted: rgb(var(--cui-controls-625));
+	/* FilledContent:highlighted – 1050 : 400 */
+	--cui-filled-color--highlighted: rgb(var(--cui-content-400));
+	--cui-filled-background-color--highlighted: rgb(var(--cui-content-1000));
+	--cui-filled-border-color--highlighted: rgb(var(--cui-content-400));
+	/* FilledControl:highlighted – 1050 : 400 */
+	--cui-filled-control-color--highlighted: rgb(var(--cui-controls-400));
 	--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-1000));
-	--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-625));
+	--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-400));
 
-	/* Filled:pressed – 1075 alpha : 575 */
-	--cui-filled-control-color--pressed: rgb(var(--cui-controls-575));
-	--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-1000), 0.175);
-	--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-775));
+	/* FilledContent:pressed – 175 alpha : 525 */
+	--cui-filled-color--pressed: rgb(var(--cui-content-525));
+	--cui-filled-background-color--pressed: rgba(var(--cui-content-175), 0.175);
+	--cui-filled-border-color--pressed: rgb(var(--cui-content-525));
+	/* FilledControl:pressed – 175 alpha : 525 */
+	--cui-filled-control-color--pressed: rgb(var(--cui-controls-525));
+	--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-175), 0.175);
+	--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-525));
 
-	/* Toned — 825 alpha : 475 */
-	--cui-toned-control-color: rgb(var(--cui-controls-475));
-	--cui-toned-control-background-color: rgba(var(--cui-controls-825), 0.500);
-	--cui-toned-control-border-color: rgb(var(--cui-controls-475));
+	/* FilledPrimaryContent — 375 : rgb(var(--cui-content-350)) */
+	--cui-filled-primary-color: rgb(var(--cui-content-975));
+	--cui-filled-primary-background-color: rgb(var(--cui-content-375));
+	--cui-filled-primary-border-color: rgb(var(--cui-content-975));
+	/* FilledPrimaryControl — 375 : rgb(var(--cui-controls-350)) */
+	--cui-filled-primary-control-color: rgb(var(--cui-controls-975));
+	--cui-filled-primary-control-background-color: rgb(var(--cui-controls-375));
+	--cui-filled-primary-control-border-color: rgb(var(--cui-controls-975));
 
-	/* Toned:highlighted = Filled:highlighted */
-	--cui-toned-control-color--highlighted: rgb(var(--cui-controls-625));
-	--cui-toned-control-background-color--highlighted: rgb(var(--cui-controls-1000));
-	--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-625));
+	/* FilledPrimaryContent:highlighted – 475 : 1350 */
+	--cui-filled-primary-color--highlighted: rgb(var(--cui-content-1000));
+	--cui-filled-primary-background-color--highlighted: rgb(var(--cui-content-475));
+	--cui-filled-primary-border-color--highlighted: rgb(var(--cui-content-1000));
+	/* FilledPrimaryControl:highlighted – 475 : 1350 */
+	--cui-filled-primary-control-color--highlighted: rgb(var(--cui-controls-1000));
+	--cui-filled-primary-control-background-color--highlighted: rgb(var(--cui-controls-475));
+	--cui-filled-primary-control-border-color--highlighted: rgb(var(--cui-controls-1000));
 
-	/* Toned:pressed = Filled:pressed */
-	--cui-toned-control-color--pressed: rgb(var(--cui-controls-575));
-	--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-1000), 0.175);
-	--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-775));
-}
-.scheme-light-above, .scheme-light-above *:not([class*="scheme-"]),
-.scheme-system-above, .scheme-system-above *:not([class*="scheme-"]) {
-	/* Content */
-	--cui-background-color: rgb(var(--cui-content-1000));
-	--cui-background-color--above: rgb(var(--cui-content-1000));
-	--cui-background-color--below: rgb(var(--cui-content-975));
-	--cui-color: rgba(var(--cui-content-125), 0.750);
-	--cui-color--strong: rgb(var(--cui-content-125));
-	--cui-color--high: rgba(var(--cui-content-125), 0.750);
-	--cui-color--medium: rgba(var(--cui-content-125), 0.500);
-	--cui-color--low: rgba(var(--cui-content-125), 0.300);
-	--cui-color--lower: rgba(var(--cui-content-125), 0.125);
+	/* FilledPrimaryContent:pressed – 375 alpha : 775 */
+	--cui-filled-primary-color--pressed: rgb(var(--cui-content-775));
+	--cui-filled-primary-background-color--pressed: rgb(var(--cui-content-375));
+	--cui-filled-primary-border-color--pressed: rgb(var(--cui-content-775));
+	/* FilledPrimaryControl:pressed – 375 alpha : 775 */
+	--cui-filled-primary-control-color--pressed: rgb(var(--cui-controls-775));
+	--cui-filled-primary-control-background-color--pressed: rgb(var(--cui-controls-375));
+	--cui-filled-primary-control-border-color--pressed: rgb(var(--cui-controls-775));
 
-	/* Control – 1000 : 525*/
-	--cui-control-color: rgb(var(--cui-controls-525));
-	--cui-control-background-color: rgba(var(--cui-controls-1000), 0.00);
-	--cui-control-border-color: rgb(var(--cui-controls-525));
-
-	/* Control:highlighted – 1000 : 625 */
-	--cui-control-color--highlighted: rgb(var(--cui-controls-625));
-	--cui-control-background-color--highlighted: rgba(var(--cui-controls-1000), 0.750);
-	--cui-control-border-color--highlighted: rgb(var(--cui-controls-625));
-
-	/* Control:pressed — 1000 : 525 */
-	--cui-control-color--pressed: rgb(var(--cui-controls-600));
-	--cui-control-background-color--pressed: rgba(var(--cui-controls-1000), 0.175);
-	--cui-control-border-color--pressed: rgb(var(--cui-controls-800));
-
-	/* Filled — 1100 : rgb(var(--cui-controls-550)) */
-	--cui-filled-control-color: rgb(var(--cui-controls-550));
-	--cui-filled-control-background-color: rgb(var(--cui-controls-1000));
-	--cui-filled-control-border-color: rgb(var(--cui-controls-550));
-
-	/* Filled:highlighted – 1200 : 650 */
-	--cui-filled-control-color--highlighted: rgb(var(--cui-controls-650));
-	--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-1000));
-	--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-650));
-
-	/* Filled:pressed – 1100 alpha : 600 */
-	--cui-filled-control-color--pressed: rgb(var(--cui-controls-600));
-	--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-1000), 0.175);
-	--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-800));
-
-	/* Toned — 850 alpha : 500 */
-	--cui-toned-control-color: rgb(var(--cui-controls-500));
+	/* TonedContent — 850 alpha : 275 */
+	--cui-toned-color: rgb(var(--cui-content-275));
+	--cui-toned-background-color: rgba(var(--cui-content-850), 0.500);
+	--cui-toned-border-color: rgb(var(--cui-content-275));
+	/* TonedControl — 850 alpha : 275 */
+	--cui-toned-control-color: rgb(var(--cui-controls-275));
 	--cui-toned-control-background-color: rgba(var(--cui-controls-850), 0.500);
-	--cui-toned-control-border-color: rgb(var(--cui-controls-500));
+	--cui-toned-control-border-color: rgb(var(--cui-controls-275));
 
-	/* Toned:highlighted = Filled:highlighted */
-	--cui-toned-control-color--highlighted: rgb(var(--cui-controls-650));
-	--cui-toned-control-background-color--highlighted: rgb(var(--cui-controls-1000));
-	--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-650));
+	/* TonedContent:highlighted = FilledControl:highlighted */
+	--cui-toned-color--highlighted: rgb(var(--cui-content-1000));
+	--cui-toned-background-color--highlighted: rgb(var(--cui-content-475));
+	--cui-toned-border-color--highlighted: rgb(var(--cui-content-400));
+	/* TonedControl:highlighted = FilledControl:highlighted */
+	--cui-toned-control-color--highlighted: rgb(var(--cui-controls-475));
+	--cui-toned-control-background-color--highlighted: rgba(var(--cui-controls-1000), 0.750);
+	--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-400));
 
-	/* Toned:pressed = Filled:pressed */
-	--cui-toned-control-color--pressed: rgb(var(--cui-controls-600));
-	--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-1000), 0.175);
-	--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-800));
+	/* TonedContent:pressed = FilledControl:pressed */
+	--cui-toned-color--pressed: rgb(var(--cui-content-525));
+	--cui-toned-background-color--pressed: rgba(var(--cui-content-175), 0.175);
+	--cui-toned-border-color--pressed: rgb(var(--cui-content-525));
+	/* TonedControl:pressed = FilledControl:pressed */
+	--cui-toned-control-color--pressed: rgb(var(--cui-controls-525));
+	--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-175), 0.175);
+	--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-525));
 }
 .scheme-dark-below, .scheme-dark-below *:not([class*="scheme-"]) {
 	/* Content */
 	--cui-background-color: rgb(var(--cui-content-25));
-	--cui-background-color--above: rgb(var(--cui-content-75));
+	--cui-background-color--above: rgb(var(--cui-content-50));
 	--cui-background-color--below: rgb(var(--cui-content-0));
-	--cui-color: rgba(var(--cui-content-825), 0.750);
-	--cui-color--strong: rgb(var(--cui-content-825));
-	--cui-color--high: rgba(var(--cui-content-825), 0.750);
-	--cui-color--medium: rgba(var(--cui-content-825), 0.500);
-	--cui-color--low: rgba(var(--cui-content-825), 0.300);
-	--cui-color--lower: rgba(var(--cui-content-825), 0.125);
+	--cui-color: rgba(var(--cui-content-1000), 0.750);
+	--cui-color--strong: rgb(var(--cui-content-1000));
+	--cui-color--high: rgba(var(--cui-content-1000), 0.750);
+	--cui-color--medium: rgba(var(--cui-content-1000), 0.500);
+	--cui-color--low: rgba(var(--cui-content-1000), 0.300);
+	--cui-color--lower: rgba(var(--cui-content-1000), 0.125);
 
-	/* Control – 25 : 525*/
-	--cui-control-color: rgb(var(--cui-controls-525));
-	--cui-control-background-color: rgba(var(--cui-controls-25), 0.00);
-	--cui-control-border-color: rgb(var(--cui-controls-525));
+	/* Control – 25 : 600*/
+	--cui-control-color: rgb(var(--cui-controls-600));
+	--cui-control-background-color: rgba(var(--cui-controls-0), 0.250);
+	--cui-control-border-color: rgb(var(--cui-controls-575));
 
+	/* Content:highlighted – 25 : 925 */
+	--cui-color--highlighted: rgb(var(--cui-content-925));
+	--cui-background-color--highlighted: rgba(var(--cui-content-275), 0.750);
+	--cui-border-color--highlighted: rgb(var(--cui-content-925));
 	/* Control:highlighted – 25 : 925 */
 	--cui-control-color--highlighted: rgb(var(--cui-controls-925));
-	--cui-control-background-color--highlighted: rgba(var(--cui-controls-525), 0.750);
+	--cui-control-background-color--highlighted: rgba(var(--cui-controls-275), 0.750);
 	--cui-control-border-color--highlighted: rgb(var(--cui-controls-925));
 
-	/* Control:pressed — 25 : 525 */
+	/* Content:pressed — 25 : 575 */
+	--cui-color--pressed: rgb(var(--cui-content-675));
+	--cui-background-color--pressed: rgba(var(--cui-content-100), 0.750);
+	--cui-border-color--pressed: rgb(var(--cui-content-675));
+	/* Control:pressed — 25 : 575 */
 	--cui-control-color--pressed: rgb(var(--cui-controls-675));
-	--cui-control-background-color--pressed: rgba(var(--cui-controls-0), 0.750);
-	--cui-control-border-color--pressed: rgb(var(--cui-controls-275));
+	--cui-control-background-color--pressed: rgba(var(--cui-controls-100), 0.750);
+	--cui-control-border-color--pressed: rgb(var(--cui-controls-675));
 
-	/* Filled — 375 : rgb(var(--cui-controls-925)) */
-	--cui-filled-control-color: rgb(var(--cui-controls-925));
-	--cui-filled-control-background-color: rgb(var(--cui-controls-375));
-	--cui-filled-control-border-color: rgb(var(--cui-controls-925));
+	/* FilledContent — 125 : rgb(var(--cui-content-650)) */
+	--cui-filled-color: rgb(var(--cui-content-650));
+	--cui-filled-background-color: rgb(var(--cui-content-125));
+	--cui-filled-border-color: rgb(var(--cui-content-650));
+	/* FilledControl — 125 : rgb(var(--cui-controls-650)) */
+	--cui-filled-control-color: rgb(var(--cui-controls-650));
+	--cui-filled-control-background-color: rgb(var(--cui-controls-125));
+	--cui-filled-control-border-color: rgb(var(--cui-controls-650));
 
-	/* Filled:highlighted – 475 : 1025 */
-	--cui-filled-control-color--highlighted: rgb(var(--cui-controls-1000));
-	--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-475));
-	--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+	/* FilledContent:highlighted – 275 : 900 */
+	--cui-filled-color--highlighted: rgb(var(--cui-content-900));
+	--cui-filled-background-color--highlighted: rgb(var(--cui-content-275));
+	--cui-filled-border-color--highlighted: rgb(var(--cui-content-900));
+	/* FilledControl:highlighted – 275 : 900 */
+	--cui-filled-control-color--highlighted: rgb(var(--cui-controls-900));
+	--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-275));
+	--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-900));
 
-	/* Filled:pressed – -25 alpha : 675 */
+	/* FilledContent:pressed – 100 alpha : 675 */
+	--cui-filled-color--pressed: rgb(var(--cui-content-675));
+	--cui-filled-background-color--pressed: rgba(var(--cui-content-100), 0.750);
+	--cui-filled-border-color--pressed: rgb(var(--cui-content-675));
+	/* FilledControl:pressed – 100 alpha : 675 */
 	--cui-filled-control-color--pressed: rgb(var(--cui-controls-675));
-	--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-0), 0.750);
-	--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-275));
+	--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-100), 0.750);
+	--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-675));
 
-	/* Toned — 225 alpha : 925 */
-	--cui-toned-control-color: rgb(var(--cui-controls-925));
-	--cui-toned-control-background-color: rgba(var(--cui-controls-225), 0.750);
-	--cui-toned-control-border-color: rgb(var(--cui-controls-925));
+	/* FilledPrimaryContent — 275 : rgb(var(--cui-content-650)) */
+	--cui-filled-primary-color: rgb(var(--cui-content-900));
+	--cui-filled-primary-background-color: rgb(var(--cui-content-275));
+	--cui-filled-primary-border-color: rgb(var(--cui-content-900));
+	/* FilledPrimaryControl — 275 : rgb(var(--cui-controls-650)) */
+	--cui-filled-primary-control-color: rgb(var(--cui-controls-900));
+	--cui-filled-primary-control-background-color: rgb(var(--cui-controls-275));
+	--cui-filled-primary-control-border-color: rgb(var(--cui-controls-900));
 
-	/* Toned:highlighted = Filled:highlighted */
-	--cui-toned-control-color--highlighted: rgb(var(--cui-controls-1000));
-	--cui-toned-control-background-color--highlighted: rgb(var(--cui-controls-475));
-	--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+	/* FilledPrimaryContent:highlighted – 375 : 1025 */
+	--cui-filled-primary-color--highlighted: rgb(var(--cui-content-1000));
+	--cui-filled-primary-background-color--highlighted: rgb(var(--cui-content-375));
+	--cui-filled-primary-border-color--highlighted: rgb(var(--cui-content-1000));
+	/* FilledPrimaryControl:highlighted – 375 : 1025 */
+	--cui-filled-primary-control-color--highlighted: rgb(var(--cui-controls-1000));
+	--cui-filled-primary-control-background-color--highlighted: rgb(var(--cui-controls-375));
+	--cui-filled-primary-control-border-color--highlighted: rgb(var(--cui-controls-1000));
 
-	/* Toned:pressed = Filled:pressed */
+	/* FilledPrimaryContent:pressed – 150 alpha : 625 */
+	--cui-filled-primary-color--pressed: rgb(var(--cui-content-625));
+	--cui-filled-primary-background-color--pressed: rgb(var(--cui-content-150));
+	--cui-filled-primary-border-color--pressed: rgb(var(--cui-content-625));
+	/* FilledPrimaryControl:pressed – 150 alpha : 625 */
+	--cui-filled-primary-control-color--pressed: rgb(var(--cui-controls-625));
+	--cui-filled-primary-control-background-color--pressed: rgb(var(--cui-controls-150));
+	--cui-filled-primary-control-border-color--pressed: rgb(var(--cui-controls-625));
+
+	/* TonedContent — 275 alpha : 875 */
+	--cui-toned-color: rgb(var(--cui-content-875));
+	--cui-toned-background-color: rgba(var(--cui-content-275), 0.250);
+	--cui-toned-border-color: rgb(var(--cui-content-875));
+	/* TonedControl — 275 alpha : 875 */
+	--cui-toned-control-color: rgb(var(--cui-controls-875));
+	--cui-toned-control-background-color: rgba(var(--cui-controls-275), 0.250);
+	--cui-toned-control-border-color: rgb(var(--cui-controls-875));
+
+	/* TonedContent:highlighted = FilledControl:highlighted */
+	--cui-toned-color--highlighted: rgb(var(--cui-content-1000));
+	--cui-toned-background-color--highlighted: rgb(var(--cui-content-375));
+	--cui-toned-border-color--highlighted: rgb(var(--cui-content-900));
+	/* TonedControl:highlighted = FilledControl:highlighted */
+	--cui-toned-control-color--highlighted: rgb(var(--cui-controls-975));
+	--cui-toned-control-background-color--highlighted: rgba(var(--cui-controls-350), 0.875);
+	--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-900));
+
+	/* TonedContent:pressed = FilledControl:pressed */
+	--cui-toned-color--pressed: rgb(var(--cui-content-675));
+	--cui-toned-background-color--pressed: rgba(var(--cui-content-100), 0.750);
+	--cui-toned-border-color--pressed: rgb(var(--cui-content-675));
+	/* TonedControl:pressed = FilledControl:pressed */
 	--cui-toned-control-color--pressed: rgb(var(--cui-controls-675));
-	--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-0), 0.750);
-	--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-275));
+	--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-100), 0.750);
+	--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-675));
 }
 .scheme-dark, .scheme-dark *:not([class*="scheme-"]) {
 	/* Content */
-	--cui-background-color: rgb(var(--cui-content-75));
-	--cui-background-color--above: rgb(var(--cui-content-125));
+	--cui-background-color: rgb(var(--cui-content-50));
+	--cui-background-color--above: rgb(var(--cui-content-75));
 	--cui-background-color--below: rgb(var(--cui-content-25));
-	--cui-color: rgba(var(--cui-content-875), 0.750);
-	--cui-color--strong: rgb(var(--cui-content-875));
-	--cui-color--high: rgba(var(--cui-content-875), 0.750);
-	--cui-color--medium: rgba(var(--cui-content-875), 0.500);
-	--cui-color--low: rgba(var(--cui-content-875), 0.300);
-	--cui-color--lower: rgba(var(--cui-content-875), 0.125);
+	--cui-color: rgba(var(--cui-content-1000), 0.750);
+	--cui-color--strong: rgb(var(--cui-content-1000));
+	--cui-color--high: rgba(var(--cui-content-1000), 0.750);
+	--cui-color--medium: rgba(var(--cui-content-1000), 0.500);
+	--cui-color--low: rgba(var(--cui-content-1000), 0.300);
+	--cui-color--lower: rgba(var(--cui-content-1000), 0.125);
 
-	/* Control – 75 : 575*/
-	--cui-control-color: rgb(var(--cui-controls-575));
-	--cui-control-background-color: rgba(var(--cui-controls-75), 0.00);
-	--cui-control-border-color: rgb(var(--cui-controls-575));
+	/* Control – 50 : 625*/
+	--cui-control-color: rgb(var(--cui-controls-625));
+	--cui-control-background-color: rgba(var(--cui-controls-0), 0.250);
+	--cui-control-border-color: rgb(var(--cui-controls-600));
 
-	/* Control:highlighted – 75 : 975 */
-	--cui-control-color--highlighted: rgb(var(--cui-controls-975));
-	--cui-control-background-color--highlighted: rgba(var(--cui-controls-575), 0.750);
-	--cui-control-border-color--highlighted: rgb(var(--cui-controls-975));
+	/* Content:highlighted – 50 : 950 */
+	--cui-color--highlighted: rgb(var(--cui-content-950));
+	--cui-background-color--highlighted: rgba(var(--cui-content-300), 0.750);
+	--cui-border-color--highlighted: rgb(var(--cui-content-950));
+	/* Control:highlighted – 50 : 950 */
+	--cui-control-color--highlighted: rgb(var(--cui-controls-950));
+	--cui-control-background-color--highlighted: rgba(var(--cui-controls-300), 0.750);
+	--cui-control-border-color--highlighted: rgb(var(--cui-controls-950));
 
-	/* Control:pressed — 75 : 575 */
-	--cui-control-color--pressed: rgb(var(--cui-controls-725));
-	--cui-control-background-color--pressed: rgba(var(--cui-controls-25), 0.750);
-	--cui-control-border-color--pressed: rgb(var(--cui-controls-325));
+	/* Content:pressed — 50 : 600 */
+	--cui-color--pressed: rgb(var(--cui-content-700));
+	--cui-background-color--pressed: rgba(var(--cui-content-125), 0.750);
+	--cui-border-color--pressed: rgb(var(--cui-content-700));
+	/* Control:pressed — 50 : 600 */
+	--cui-control-color--pressed: rgb(var(--cui-controls-700));
+	--cui-control-background-color--pressed: rgba(var(--cui-controls-125), 0.750);
+	--cui-control-border-color--pressed: rgb(var(--cui-controls-700));
 
-	/* Filled — 425 : rgb(var(--cui-controls-975)) */
-	--cui-filled-control-color: rgb(var(--cui-controls-975));
-	--cui-filled-control-background-color: rgb(var(--cui-controls-425));
-	--cui-filled-control-border-color: rgb(var(--cui-controls-975));
+	/* FilledContent — 150 : rgb(var(--cui-content-675)) */
+	--cui-filled-color: rgb(var(--cui-content-675));
+	--cui-filled-background-color: rgb(var(--cui-content-150));
+	--cui-filled-border-color: rgb(var(--cui-content-675));
+	/* FilledControl — 150 : rgb(var(--cui-controls-675)) */
+	--cui-filled-control-color: rgb(var(--cui-controls-675));
+	--cui-filled-control-background-color: rgb(var(--cui-controls-150));
+	--cui-filled-control-border-color: rgb(var(--cui-controls-675));
 
-	/* Filled:highlighted – 525 : 1075 */
-	--cui-filled-control-color--highlighted: rgb(var(--cui-controls-1000));
-	--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-525));
-	--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+	/* FilledContent:highlighted – 300 : 925 */
+	--cui-filled-color--highlighted: rgb(var(--cui-content-925));
+	--cui-filled-background-color--highlighted: rgb(var(--cui-content-300));
+	--cui-filled-border-color--highlighted: rgb(var(--cui-content-925));
+	/* FilledControl:highlighted – 300 : 925 */
+	--cui-filled-control-color--highlighted: rgb(var(--cui-controls-925));
+	--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-300));
+	--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-925));
 
-	/* Filled:pressed – 25 alpha : 725 */
-	--cui-filled-control-color--pressed: rgb(var(--cui-controls-725));
-	--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-25), 0.750);
-	--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-325));
+	/* FilledContent:pressed – 125 alpha : 700 */
+	--cui-filled-color--pressed: rgb(var(--cui-content-700));
+	--cui-filled-background-color--pressed: rgba(var(--cui-content-125), 0.750);
+	--cui-filled-border-color--pressed: rgb(var(--cui-content-700));
+	/* FilledControl:pressed – 125 alpha : 700 */
+	--cui-filled-control-color--pressed: rgb(var(--cui-controls-700));
+	--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-125), 0.750);
+	--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-700));
 
-	/* Toned — 275 alpha : 975 */
-	--cui-toned-control-color: rgb(var(--cui-controls-975));
-	--cui-toned-control-background-color: rgba(var(--cui-controls-275), 0.750);
-	--cui-toned-control-border-color: rgb(var(--cui-controls-975));
+	/* FilledPrimaryContent — 300 : rgb(var(--cui-content-675)) */
+	--cui-filled-primary-color: rgb(var(--cui-content-925));
+	--cui-filled-primary-background-color: rgb(var(--cui-content-300));
+	--cui-filled-primary-border-color: rgb(var(--cui-content-925));
+	/* FilledPrimaryControl — 300 : rgb(var(--cui-controls-675)) */
+	--cui-filled-primary-control-color: rgb(var(--cui-controls-925));
+	--cui-filled-primary-control-background-color: rgb(var(--cui-controls-300));
+	--cui-filled-primary-control-border-color: rgb(var(--cui-controls-925));
 
-	/* Toned:highlighted = Filled:highlighted */
+	/* FilledPrimaryContent:highlighted – 400 : 1050 */
+	--cui-filled-primary-color--highlighted: rgb(var(--cui-content-1000));
+	--cui-filled-primary-background-color--highlighted: rgb(var(--cui-content-400));
+	--cui-filled-primary-border-color--highlighted: rgb(var(--cui-content-1000));
+	/* FilledPrimaryControl:highlighted – 400 : 1050 */
+	--cui-filled-primary-control-color--highlighted: rgb(var(--cui-controls-1000));
+	--cui-filled-primary-control-background-color--highlighted: rgb(var(--cui-controls-400));
+	--cui-filled-primary-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+
+	/* FilledPrimaryContent:pressed – 175 alpha : 650 */
+	--cui-filled-primary-color--pressed: rgb(var(--cui-content-650));
+	--cui-filled-primary-background-color--pressed: rgb(var(--cui-content-175));
+	--cui-filled-primary-border-color--pressed: rgb(var(--cui-content-650));
+	/* FilledPrimaryControl:pressed – 175 alpha : 650 */
+	--cui-filled-primary-control-color--pressed: rgb(var(--cui-controls-650));
+	--cui-filled-primary-control-background-color--pressed: rgb(var(--cui-controls-175));
+	--cui-filled-primary-control-border-color--pressed: rgb(var(--cui-controls-650));
+
+	/* TonedContent — 300 alpha : 900 */
+	--cui-toned-color: rgb(var(--cui-content-900));
+	--cui-toned-background-color: rgba(var(--cui-content-300), 0.250);
+	--cui-toned-border-color: rgb(var(--cui-content-900));
+	/* TonedControl — 300 alpha : 900 */
+	--cui-toned-control-color: rgb(var(--cui-controls-900));
+	--cui-toned-control-background-color: rgba(var(--cui-controls-300), 0.250);
+	--cui-toned-control-border-color: rgb(var(--cui-controls-900));
+
+	/* TonedContent:highlighted = FilledControl:highlighted */
+	--cui-toned-color--highlighted: rgb(var(--cui-content-1000));
+	--cui-toned-background-color--highlighted: rgb(var(--cui-content-400));
+	--cui-toned-border-color--highlighted: rgb(var(--cui-content-925));
+	/* TonedControl:highlighted = FilledControl:highlighted */
 	--cui-toned-control-color--highlighted: rgb(var(--cui-controls-1000));
-	--cui-toned-control-background-color--highlighted: rgb(var(--cui-controls-525));
-	--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+	--cui-toned-control-background-color--highlighted: rgba(var(--cui-controls-375), 0.875);
+	--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-925));
 
-	/* Toned:pressed = Filled:pressed */
-	--cui-toned-control-color--pressed: rgb(var(--cui-controls-725));
-	--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-25), 0.750);
-	--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-325));
+	/* TonedContent:pressed = FilledControl:pressed */
+	--cui-toned-color--pressed: rgb(var(--cui-content-700));
+	--cui-toned-background-color--pressed: rgba(var(--cui-content-125), 0.750);
+	--cui-toned-border-color--pressed: rgb(var(--cui-content-700));
+	/* TonedControl:pressed = FilledControl:pressed */
+	--cui-toned-control-color--pressed: rgb(var(--cui-controls-700));
+	--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-125), 0.750);
+	--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-700));
 }
 .scheme-dark-above, .scheme-dark-above *:not([class*="scheme-"]) {
 	/* Content */
-	--cui-background-color: rgb(var(--cui-content-100));
-	--cui-background-color--above: rgb(var(--cui-content-150));
+	--cui-background-color: rgb(var(--cui-content-75));
+	--cui-background-color--above: rgb(var(--cui-content-100));
 	--cui-background-color--below: rgb(var(--cui-content-50));
-	--cui-color: rgba(var(--cui-content-900), 0.750);
-	--cui-color--strong: rgb(var(--cui-content-900));
-	--cui-color--high: rgba(var(--cui-content-900), 0.750);
-	--cui-color--medium: rgba(var(--cui-content-900), 0.500);
-	--cui-color--low: rgba(var(--cui-content-900), 0.300);
-	--cui-color--lower: rgba(var(--cui-content-900), 0.125);
+	--cui-color: rgba(var(--cui-content-1000), 0.750);
+	--cui-color--strong: rgb(var(--cui-content-1000));
+	--cui-color--high: rgba(var(--cui-content-1000), 0.750);
+	--cui-color--medium: rgba(var(--cui-content-1000), 0.500);
+	--cui-color--low: rgba(var(--cui-content-1000), 0.300);
+	--cui-color--lower: rgba(var(--cui-content-1000), 0.125);
 
-	/* Control – 100 : 600*/
-	--cui-control-color: rgb(var(--cui-controls-600));
-	--cui-control-background-color: rgba(var(--cui-controls-100), 0.00);
-	--cui-control-border-color: rgb(var(--cui-controls-600));
+	/* Control – 75 : 650*/
+	--cui-control-color: rgb(var(--cui-controls-650));
+	--cui-control-background-color: rgba(var(--cui-controls-0), 0.250);
+	--cui-control-border-color: rgb(var(--cui-controls-625));
 
-	/* Control:highlighted – 100 : 1000 */
-	--cui-control-color--highlighted: rgb(var(--cui-controls-1000));
-	--cui-control-background-color--highlighted: rgba(var(--cui-controls-600), 0.750);
-	--cui-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+	/* Content:highlighted – 75 : 975 */
+	--cui-color--highlighted: rgb(var(--cui-content-975));
+	--cui-background-color--highlighted: rgba(var(--cui-content-325), 0.750);
+	--cui-border-color--highlighted: rgb(var(--cui-content-975));
+	/* Control:highlighted – 75 : 975 */
+	--cui-control-color--highlighted: rgb(var(--cui-controls-975));
+	--cui-control-background-color--highlighted: rgba(var(--cui-controls-325), 0.750);
+	--cui-control-border-color--highlighted: rgb(var(--cui-controls-975));
 
-	/* Control:pressed — 100 : 600 */
-	--cui-control-color--pressed: rgb(var(--cui-controls-750));
-	--cui-control-background-color--pressed: rgba(var(--cui-controls-50), 0.750);
-	--cui-control-border-color--pressed: rgb(var(--cui-controls-350));
+	/* Content:pressed — 75 : 625 */
+	--cui-color--pressed: rgb(var(--cui-content-725));
+	--cui-background-color--pressed: rgba(var(--cui-content-150), 0.750);
+	--cui-border-color--pressed: rgb(var(--cui-content-725));
+	/* Control:pressed — 75 : 625 */
+	--cui-control-color--pressed: rgb(var(--cui-controls-725));
+	--cui-control-background-color--pressed: rgba(var(--cui-controls-150), 0.750);
+	--cui-control-border-color--pressed: rgb(var(--cui-controls-725));
 
-	/* Filled — 450 : rgb(var(--cui-controls-1000)) */
-	--cui-filled-control-color: rgb(var(--cui-controls-1000));
-	--cui-filled-control-background-color: rgb(var(--cui-controls-450));
-	--cui-filled-control-border-color: rgb(var(--cui-controls-1000));
+	/* FilledContent — 175 : rgb(var(--cui-content-700)) */
+	--cui-filled-color: rgb(var(--cui-content-700));
+	--cui-filled-background-color: rgb(var(--cui-content-175));
+	--cui-filled-border-color: rgb(var(--cui-content-700));
+	/* FilledControl — 175 : rgb(var(--cui-controls-700)) */
+	--cui-filled-control-color: rgb(var(--cui-controls-700));
+	--cui-filled-control-background-color: rgb(var(--cui-controls-175));
+	--cui-filled-control-border-color: rgb(var(--cui-controls-700));
 
-	/* Filled:highlighted – 550 : 1100 */
-	--cui-filled-control-color--highlighted: rgb(var(--cui-controls-1000));
-	--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-550));
-	--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+	/* FilledContent:highlighted – 325 : 950 */
+	--cui-filled-color--highlighted: rgb(var(--cui-content-950));
+	--cui-filled-background-color--highlighted: rgb(var(--cui-content-325));
+	--cui-filled-border-color--highlighted: rgb(var(--cui-content-950));
+	/* FilledControl:highlighted – 325 : 950 */
+	--cui-filled-control-color--highlighted: rgb(var(--cui-controls-950));
+	--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-325));
+	--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-950));
 
-	/* Filled:pressed – 50 alpha : 750 */
-	--cui-filled-control-color--pressed: rgb(var(--cui-controls-750));
-	--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-50), 0.750);
-	--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-350));
+	/* FilledContent:pressed – 150 alpha : 725 */
+	--cui-filled-color--pressed: rgb(var(--cui-content-725));
+	--cui-filled-background-color--pressed: rgba(var(--cui-content-150), 0.750);
+	--cui-filled-border-color--pressed: rgb(var(--cui-content-725));
+	/* FilledControl:pressed – 150 alpha : 725 */
+	--cui-filled-control-color--pressed: rgb(var(--cui-controls-725));
+	--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-150), 0.750);
+	--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-725));
 
-	/* Toned — 300 alpha : 1000 */
-	--cui-toned-control-color: rgb(var(--cui-controls-1000));
-	--cui-toned-control-background-color: rgba(var(--cui-controls-300), 0.750);
-	--cui-toned-control-border-color: rgb(var(--cui-controls-1000));
+	/* FilledPrimaryContent — 325 : rgb(var(--cui-content-700)) */
+	--cui-filled-primary-color: rgb(var(--cui-content-950));
+	--cui-filled-primary-background-color: rgb(var(--cui-content-325));
+	--cui-filled-primary-border-color: rgb(var(--cui-content-950));
+	/* FilledPrimaryControl — 325 : rgb(var(--cui-controls-700)) */
+	--cui-filled-primary-control-color: rgb(var(--cui-controls-950));
+	--cui-filled-primary-control-background-color: rgb(var(--cui-controls-325));
+	--cui-filled-primary-control-border-color: rgb(var(--cui-controls-950));
 
-	/* Toned:highlighted = Filled:highlighted */
+	/* FilledPrimaryContent:highlighted – 425 : 1075 */
+	--cui-filled-primary-color--highlighted: rgb(var(--cui-content-1000));
+	--cui-filled-primary-background-color--highlighted: rgb(var(--cui-content-425));
+	--cui-filled-primary-border-color--highlighted: rgb(var(--cui-content-1000));
+	/* FilledPrimaryControl:highlighted – 425 : 1075 */
+	--cui-filled-primary-control-color--highlighted: rgb(var(--cui-controls-1000));
+	--cui-filled-primary-control-background-color--highlighted: rgb(var(--cui-controls-425));
+	--cui-filled-primary-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+
+	/* FilledPrimaryContent:pressed – 200 alpha : 675 */
+	--cui-filled-primary-color--pressed: rgb(var(--cui-content-675));
+	--cui-filled-primary-background-color--pressed: rgb(var(--cui-content-200));
+	--cui-filled-primary-border-color--pressed: rgb(var(--cui-content-675));
+	/* FilledPrimaryControl:pressed – 200 alpha : 675 */
+	--cui-filled-primary-control-color--pressed: rgb(var(--cui-controls-675));
+	--cui-filled-primary-control-background-color--pressed: rgb(var(--cui-controls-200));
+	--cui-filled-primary-control-border-color--pressed: rgb(var(--cui-controls-675));
+
+	/* TonedContent — 325 alpha : 925 */
+	--cui-toned-color: rgb(var(--cui-content-925));
+	--cui-toned-background-color: rgba(var(--cui-content-325), 0.250);
+	--cui-toned-border-color: rgb(var(--cui-content-925));
+	/* TonedControl — 325 alpha : 925 */
+	--cui-toned-control-color: rgb(var(--cui-controls-925));
+	--cui-toned-control-background-color: rgba(var(--cui-controls-325), 0.250);
+	--cui-toned-control-border-color: rgb(var(--cui-controls-925));
+
+	/* TonedContent:highlighted = FilledControl:highlighted */
+	--cui-toned-color--highlighted: rgb(var(--cui-content-1000));
+	--cui-toned-background-color--highlighted: rgb(var(--cui-content-425));
+	--cui-toned-border-color--highlighted: rgb(var(--cui-content-950));
+	/* TonedControl:highlighted = FilledControl:highlighted */
 	--cui-toned-control-color--highlighted: rgb(var(--cui-controls-1000));
-	--cui-toned-control-background-color--highlighted: rgb(var(--cui-controls-550));
-	--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+	--cui-toned-control-background-color--highlighted: rgba(var(--cui-controls-400), 0.875);
+	--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-950));
 
-	/* Toned:pressed = Filled:pressed */
-	--cui-toned-control-color--pressed: rgb(var(--cui-controls-750));
-	--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-50), 0.750);
-	--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-350));
+	/* TonedContent:pressed = FilledControl:pressed */
+	--cui-toned-color--pressed: rgb(var(--cui-content-725));
+	--cui-toned-background-color--pressed: rgba(var(--cui-content-150), 0.750);
+	--cui-toned-border-color--pressed: rgb(var(--cui-content-725));
+	/* TonedControl:pressed = FilledControl:pressed */
+	--cui-toned-control-color--pressed: rgb(var(--cui-controls-725));
+	--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-150), 0.750);
+	--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-725));
 }
 
 /*** Prefers dark scheme defaults: ***/
@@ -1720,10 +2089,10 @@
 		--cui-opacity--medium: 0.500;
 		--cui-opacity--low: 0.300;
 		--cui-opacity--lower: 0.125;
-		--cui-opacity--control-background-color: 0.000;
+		--cui-opacity--control-background-color: 0.250;
 		--cui-opacity--control-background-color--highlighted: 0.750;
 		--cui-opacity--filled-control-background-color--pressed: 0.750;
-		--cui-opacity--toned-control-background-color: 0.750;
+		--cui-opacity--toned-control-background-color: 0.250;
 	}
 	.scheme-light,
 	.scheme-light-above,
@@ -1734,7 +2103,7 @@
 		--cui-opacity--medium: 0.500;
 		--cui-opacity--low: 0.300;
 		--cui-opacity--lower: 0.125;
-		--cui-opacity--control-background-color: 0.000;
+		--cui-opacity--control-background-color: 0.250;
 		--cui-opacity--control-background-color--highlighted: 0.750;
 		--cui-opacity--filled-control-background-color--pressed: 0.175;
 		--cui-opacity--toned-control-background-color: 0.500;
@@ -1743,178 +2112,472 @@
 	.scheme-system-below, .scheme-system-below *:not([class*="scheme-"]) {
 		/* Content */
 		--cui-background-color: rgb(var(--cui-content-25));
-		--cui-background-color--above: rgb(var(--cui-content-75));
+		--cui-background-color--above: rgb(var(--cui-content-50));
 		--cui-background-color--below: rgb(var(--cui-content-0));
-		--cui-color: rgba(var(--cui-content-825), 0.750);
-		--cui-color--strong: rgb(var(--cui-content-825));
-		--cui-color--high: rgba(var(--cui-content-825), 0.750);
-		--cui-color--medium: rgba(var(--cui-content-825), 0.500);
-		--cui-color--low: rgba(var(--cui-content-825), 0.300);
-		--cui-color--lower: rgba(var(--cui-content-825), 0.125);
+		--cui-color: rgba(var(--cui-content-1000), 0.750);
+		--cui-color--strong: rgb(var(--cui-content-1000));
+		--cui-color--high: rgba(var(--cui-content-1000), 0.750);
+		--cui-color--medium: rgba(var(--cui-content-1000), 0.500);
+		--cui-color--low: rgba(var(--cui-content-1000), 0.300);
+		--cui-color--lower: rgba(var(--cui-content-1000), 0.125);
 
-		/* Control – 25 : 525*/
-		--cui-control-color: rgb(var(--cui-controls-525));
-		--cui-control-background-color: rgba(var(--cui-controls-25), 0.00);
-		--cui-control-border-color: rgb(var(--cui-controls-525));
+		/* Control – 25 : 600*/
+		--cui-control-color: rgb(var(--cui-controls-600));
+		--cui-control-background-color: rgba(var(--cui-controls-0), 0.250);
+		--cui-control-border-color: rgb(var(--cui-controls-575));
 
+		/* Content:highlighted – 25 : 925 */
+		--cui-color--highlighted: rgb(var(--cui-content-925));
+		--cui-background-color--highlighted: rgba(var(--cui-content-275), 0.750);
+		--cui-border-color--highlighted: rgb(var(--cui-content-925));
 		/* Control:highlighted – 25 : 925 */
 		--cui-control-color--highlighted: rgb(var(--cui-controls-925));
-		--cui-control-background-color--highlighted: rgba(var(--cui-controls-525), 0.750);
+		--cui-control-background-color--highlighted: rgba(var(--cui-controls-275), 0.750);
 		--cui-control-border-color--highlighted: rgb(var(--cui-controls-925));
 
-		/* Control:pressed — 25 : 525 */
+		/* Content:pressed — 25 : 575 */
+		--cui-color--pressed: rgb(var(--cui-content-675));
+		--cui-background-color--pressed: rgba(var(--cui-content-100), 0.750);
+		--cui-border-color--pressed: rgb(var(--cui-content-675));
+		/* Control:pressed — 25 : 575 */
 		--cui-control-color--pressed: rgb(var(--cui-controls-675));
-		--cui-control-background-color--pressed: rgba(var(--cui-controls-0), 0.750);
-		--cui-control-border-color--pressed: rgb(var(--cui-controls-275));
+		--cui-control-background-color--pressed: rgba(var(--cui-controls-100), 0.750);
+		--cui-control-border-color--pressed: rgb(var(--cui-controls-675));
 
-		/* Filled — 375 : rgb(var(--cui-controls-925)) */
-		--cui-filled-control-color: rgb(var(--cui-controls-925));
-		--cui-filled-control-background-color: rgb(var(--cui-controls-375));
-		--cui-filled-control-border-color: rgb(var(--cui-controls-925));
+		/* FilledContent — 125 : rgb(var(--cui-content-650)) */
+		--cui-filled-color: rgb(var(--cui-content-650));
+		--cui-filled-background-color: rgb(var(--cui-content-125));
+		--cui-filled-border-color: rgb(var(--cui-content-650));
+		/* FilledControl — 125 : rgb(var(--cui-controls-650)) */
+		--cui-filled-control-color: rgb(var(--cui-controls-650));
+		--cui-filled-control-background-color: rgb(var(--cui-controls-125));
+		--cui-filled-control-border-color: rgb(var(--cui-controls-650));
 
-		/* Filled:highlighted – 475 : 1025 */
-		--cui-filled-control-color--highlighted: rgb(var(--cui-controls-1000));
-		--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-475));
-		--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+		/* FilledContent:highlighted – 275 : 900 */
+		--cui-filled-color--highlighted: rgb(var(--cui-content-900));
+		--cui-filled-background-color--highlighted: rgb(var(--cui-content-275));
+		--cui-filled-border-color--highlighted: rgb(var(--cui-content-900));
+		/* FilledControl:highlighted – 275 : 900 */
+		--cui-filled-control-color--highlighted: rgb(var(--cui-controls-900));
+		--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-275));
+		--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-900));
 
-		/* Filled:pressed – -25 alpha : 675 */
+		/* FilledContent:pressed – 100 alpha : 675 */
+		--cui-filled-color--pressed: rgb(var(--cui-content-675));
+		--cui-filled-background-color--pressed: rgba(var(--cui-content-100), 0.750);
+		--cui-filled-border-color--pressed: rgb(var(--cui-content-675));
+		/* FilledControl:pressed – 100 alpha : 675 */
 		--cui-filled-control-color--pressed: rgb(var(--cui-controls-675));
-		--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-0), 0.750);
-		--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-275));
+		--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-100), 0.750);
+		--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-675));
 
-		/* Toned — 225 alpha : 925 */
-		--cui-toned-control-color: rgb(var(--cui-controls-925));
-		--cui-toned-control-background-color: rgba(var(--cui-controls-225), 0.750);
-		--cui-toned-control-border-color: rgb(var(--cui-controls-925));
+		/* FilledPrimaryContent — 275 : rgb(var(--cui-content-650)) */
+		--cui-filled-primary-color: rgb(var(--cui-content-900));
+		--cui-filled-primary-background-color: rgb(var(--cui-content-275));
+		--cui-filled-primary-border-color: rgb(var(--cui-content-900));
+		/* FilledPrimaryControl — 275 : rgb(var(--cui-controls-650)) */
+		--cui-filled-primary-control-color: rgb(var(--cui-controls-900));
+		--cui-filled-primary-control-background-color: rgb(var(--cui-controls-275));
+		--cui-filled-primary-control-border-color: rgb(var(--cui-controls-900));
 
-		/* Toned:highlighted = Filled:highlighted */
-		--cui-toned-control-color--highlighted: rgb(var(--cui-controls-1000));
-		--cui-toned-control-background-color--highlighted: rgb(var(--cui-controls-475));
-		--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+		/* FilledPrimaryContent:highlighted – 375 : 1025 */
+		--cui-filled-primary-color--highlighted: rgb(var(--cui-content-1000));
+		--cui-filled-primary-background-color--highlighted: rgb(var(--cui-content-375));
+		--cui-filled-primary-border-color--highlighted: rgb(var(--cui-content-1000));
+		/* FilledPrimaryControl:highlighted – 375 : 1025 */
+		--cui-filled-primary-control-color--highlighted: rgb(var(--cui-controls-1000));
+		--cui-filled-primary-control-background-color--highlighted: rgb(var(--cui-controls-375));
+		--cui-filled-primary-control-border-color--highlighted: rgb(var(--cui-controls-1000));
 
-		/* Toned:pressed = Filled:pressed */
+		/* FilledPrimaryContent:pressed – 150 alpha : 625 */
+		--cui-filled-primary-color--pressed: rgb(var(--cui-content-625));
+		--cui-filled-primary-background-color--pressed: rgb(var(--cui-content-150));
+		--cui-filled-primary-border-color--pressed: rgb(var(--cui-content-625));
+		/* FilledPrimaryControl:pressed – 150 alpha : 625 */
+		--cui-filled-primary-control-color--pressed: rgb(var(--cui-controls-625));
+		--cui-filled-primary-control-background-color--pressed: rgb(var(--cui-controls-150));
+		--cui-filled-primary-control-border-color--pressed: rgb(var(--cui-controls-625));
+
+		/* TonedContent — 275 alpha : 875 */
+		--cui-toned-color: rgb(var(--cui-content-875));
+		--cui-toned-background-color: rgba(var(--cui-content-275), 0.250);
+		--cui-toned-border-color: rgb(var(--cui-content-875));
+		/* TonedControl — 275 alpha : 875 */
+		--cui-toned-control-color: rgb(var(--cui-controls-875));
+		--cui-toned-control-background-color: rgba(var(--cui-controls-275), 0.250);
+		--cui-toned-control-border-color: rgb(var(--cui-controls-875));
+
+		/* TonedContent:highlighted = FilledControl:highlighted */
+		--cui-toned-color--highlighted: rgb(var(--cui-content-1000));
+		--cui-toned-background-color--highlighted: rgb(var(--cui-content-375));
+		--cui-toned-border-color--highlighted: rgb(var(--cui-content-900));
+		/* TonedControl:highlighted = FilledControl:highlighted */
+		--cui-toned-control-color--highlighted: rgb(var(--cui-controls-975));
+		--cui-toned-control-background-color--highlighted: rgba(var(--cui-controls-350), 0.875);
+		--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-900));
+
+		/* TonedContent:pressed = FilledControl:pressed */
+		--cui-toned-color--pressed: rgb(var(--cui-content-675));
+		--cui-toned-background-color--pressed: rgba(var(--cui-content-100), 0.750);
+		--cui-toned-border-color--pressed: rgb(var(--cui-content-675));
+		/* TonedControl:pressed = FilledControl:pressed */
 		--cui-toned-control-color--pressed: rgb(var(--cui-controls-675));
-		--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-0), 0.750);
-		--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-275));
+		--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-100), 0.750);
+		--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-675));
 	}
 	:root, :root *:not([class*="scheme-"]),
 	.scheme-dark, .scheme-dark *:not([class*="scheme-"]),
 	.scheme-system, .scheme-system *:not([class*="scheme-"]) {
 		/* Content */
-		--cui-background-color: rgb(var(--cui-content-75));
-		--cui-background-color--above: rgb(var(--cui-content-125));
+		--cui-background-color: rgb(var(--cui-content-50));
+		--cui-background-color--above: rgb(var(--cui-content-75));
 		--cui-background-color--below: rgb(var(--cui-content-25));
-		--cui-color: rgba(var(--cui-content-875), 0.750);
-		--cui-color--strong: rgb(var(--cui-content-875));
-		--cui-color--high: rgba(var(--cui-content-875), 0.750);
-		--cui-color--medium: rgba(var(--cui-content-875), 0.500);
-		--cui-color--low: rgba(var(--cui-content-875), 0.300);
-		--cui-color--lower: rgba(var(--cui-content-875), 0.125);
+		--cui-color: rgba(var(--cui-content-1000), 0.750);
+		--cui-color--strong: rgb(var(--cui-content-1000));
+		--cui-color--high: rgba(var(--cui-content-1000), 0.750);
+		--cui-color--medium: rgba(var(--cui-content-1000), 0.500);
+		--cui-color--low: rgba(var(--cui-content-1000), 0.300);
+		--cui-color--lower: rgba(var(--cui-content-1000), 0.125);
 
-		/* Control – 75 : 575*/
-		--cui-control-color: rgb(var(--cui-controls-575));
-		--cui-control-background-color: rgba(var(--cui-controls-75), 0.00);
-		--cui-control-border-color: rgb(var(--cui-controls-575));
+		/* Control – 50 : 625*/
+		--cui-control-color: rgb(var(--cui-controls-625));
+		--cui-control-background-color: rgba(var(--cui-controls-0), 0.250);
+		--cui-control-border-color: rgb(var(--cui-controls-600));
 
-		/* Control:highlighted – 75 : 975 */
-		--cui-control-color--highlighted: rgb(var(--cui-controls-975));
-		--cui-control-background-color--highlighted: rgba(var(--cui-controls-575), 0.750);
-		--cui-control-border-color--highlighted: rgb(var(--cui-controls-975));
+		/* Content:highlighted – 50 : 950 */
+		--cui-color--highlighted: rgb(var(--cui-content-950));
+		--cui-background-color--highlighted: rgba(var(--cui-content-300), 0.750);
+		--cui-border-color--highlighted: rgb(var(--cui-content-950));
+		/* Control:highlighted – 50 : 950 */
+		--cui-control-color--highlighted: rgb(var(--cui-controls-950));
+		--cui-control-background-color--highlighted: rgba(var(--cui-controls-300), 0.750);
+		--cui-control-border-color--highlighted: rgb(var(--cui-controls-950));
 
-		/* Control:pressed — 75 : 575 */
-		--cui-control-color--pressed: rgb(var(--cui-controls-725));
-		--cui-control-background-color--pressed: rgba(var(--cui-controls-25), 0.750);
-		--cui-control-border-color--pressed: rgb(var(--cui-controls-325));
+		/* Content:pressed — 50 : 600 */
+		--cui-color--pressed: rgb(var(--cui-content-700));
+		--cui-background-color--pressed: rgba(var(--cui-content-125), 0.750);
+		--cui-border-color--pressed: rgb(var(--cui-content-700));
+		/* Control:pressed — 50 : 600 */
+		--cui-control-color--pressed: rgb(var(--cui-controls-700));
+		--cui-control-background-color--pressed: rgba(var(--cui-controls-125), 0.750);
+		--cui-control-border-color--pressed: rgb(var(--cui-controls-700));
 
-		/* Filled — 425 : rgb(var(--cui-controls-975)) */
-		--cui-filled-control-color: rgb(var(--cui-controls-975));
-		--cui-filled-control-background-color: rgb(var(--cui-controls-425));
-		--cui-filled-control-border-color: rgb(var(--cui-controls-975));
+		/* FilledContent — 150 : rgb(var(--cui-content-675)) */
+		--cui-filled-color: rgb(var(--cui-content-675));
+		--cui-filled-background-color: rgb(var(--cui-content-150));
+		--cui-filled-border-color: rgb(var(--cui-content-675));
+		/* FilledControl — 150 : rgb(var(--cui-controls-675)) */
+		--cui-filled-control-color: rgb(var(--cui-controls-675));
+		--cui-filled-control-background-color: rgb(var(--cui-controls-150));
+		--cui-filled-control-border-color: rgb(var(--cui-controls-675));
 
-		/* Filled:highlighted – 525 : 1075 */
-		--cui-filled-control-color--highlighted: rgb(var(--cui-controls-1000));
-		--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-525));
-		--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+		/* FilledContent:highlighted – 300 : 925 */
+		--cui-filled-color--highlighted: rgb(var(--cui-content-925));
+		--cui-filled-background-color--highlighted: rgb(var(--cui-content-300));
+		--cui-filled-border-color--highlighted: rgb(var(--cui-content-925));
+		/* FilledControl:highlighted – 300 : 925 */
+		--cui-filled-control-color--highlighted: rgb(var(--cui-controls-925));
+		--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-300));
+		--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-925));
 
-		/* Filled:pressed – 25 alpha : 725 */
-		--cui-filled-control-color--pressed: rgb(var(--cui-controls-725));
-		--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-25), 0.750);
-		--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-325));
+		/* FilledContent:pressed – 125 alpha : 700 */
+		--cui-filled-color--pressed: rgb(var(--cui-content-700));
+		--cui-filled-background-color--pressed: rgba(var(--cui-content-125), 0.750);
+		--cui-filled-border-color--pressed: rgb(var(--cui-content-700));
+		/* FilledControl:pressed – 125 alpha : 700 */
+		--cui-filled-control-color--pressed: rgb(var(--cui-controls-700));
+		--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-125), 0.750);
+		--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-700));
 
-		/* Toned — 275 alpha : 975 */
-		--cui-toned-control-color: rgb(var(--cui-controls-975));
-		--cui-toned-control-background-color: rgba(var(--cui-controls-275), 0.750);
-		--cui-toned-control-border-color: rgb(var(--cui-controls-975));
+		/* FilledPrimaryContent — 300 : rgb(var(--cui-content-675)) */
+		--cui-filled-primary-color: rgb(var(--cui-content-925));
+		--cui-filled-primary-background-color: rgb(var(--cui-content-300));
+		--cui-filled-primary-border-color: rgb(var(--cui-content-925));
+		/* FilledPrimaryControl — 300 : rgb(var(--cui-controls-675)) */
+		--cui-filled-primary-control-color: rgb(var(--cui-controls-925));
+		--cui-filled-primary-control-background-color: rgb(var(--cui-controls-300));
+		--cui-filled-primary-control-border-color: rgb(var(--cui-controls-925));
 
-		/* Toned:highlighted = Filled:highlighted */
+		/* FilledPrimaryContent:highlighted – 400 : 1050 */
+		--cui-filled-primary-color--highlighted: rgb(var(--cui-content-1000));
+		--cui-filled-primary-background-color--highlighted: rgb(var(--cui-content-400));
+		--cui-filled-primary-border-color--highlighted: rgb(var(--cui-content-1000));
+		/* FilledPrimaryControl:highlighted – 400 : 1050 */
+		--cui-filled-primary-control-color--highlighted: rgb(var(--cui-controls-1000));
+		--cui-filled-primary-control-background-color--highlighted: rgb(var(--cui-controls-400));
+		--cui-filled-primary-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+
+		/* FilledPrimaryContent:pressed – 175 alpha : 650 */
+		--cui-filled-primary-color--pressed: rgb(var(--cui-content-650));
+		--cui-filled-primary-background-color--pressed: rgb(var(--cui-content-175));
+		--cui-filled-primary-border-color--pressed: rgb(var(--cui-content-650));
+		/* FilledPrimaryControl:pressed – 175 alpha : 650 */
+		--cui-filled-primary-control-color--pressed: rgb(var(--cui-controls-650));
+		--cui-filled-primary-control-background-color--pressed: rgb(var(--cui-controls-175));
+		--cui-filled-primary-control-border-color--pressed: rgb(var(--cui-controls-650));
+
+		/* TonedContent — 300 alpha : 900 */
+		--cui-toned-color: rgb(var(--cui-content-900));
+		--cui-toned-background-color: rgba(var(--cui-content-300), 0.250);
+		--cui-toned-border-color: rgb(var(--cui-content-900));
+		/* TonedControl — 300 alpha : 900 */
+		--cui-toned-control-color: rgb(var(--cui-controls-900));
+		--cui-toned-control-background-color: rgba(var(--cui-controls-300), 0.250);
+		--cui-toned-control-border-color: rgb(var(--cui-controls-900));
+
+		/* TonedContent:highlighted = FilledControl:highlighted */
+		--cui-toned-color--highlighted: rgb(var(--cui-content-1000));
+		--cui-toned-background-color--highlighted: rgb(var(--cui-content-400));
+		--cui-toned-border-color--highlighted: rgb(var(--cui-content-925));
+		/* TonedControl:highlighted = FilledControl:highlighted */
 		--cui-toned-control-color--highlighted: rgb(var(--cui-controls-1000));
-		--cui-toned-control-background-color--highlighted: rgb(var(--cui-controls-525));
-		--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+		--cui-toned-control-background-color--highlighted: rgba(var(--cui-controls-375), 0.875);
+		--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-925));
 
-		/* Toned:pressed = Filled:pressed */
-		--cui-toned-control-color--pressed: rgb(var(--cui-controls-725));
-		--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-25), 0.750);
-		--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-325));
+		/* TonedContent:pressed = FilledControl:pressed */
+		--cui-toned-color--pressed: rgb(var(--cui-content-700));
+		--cui-toned-background-color--pressed: rgba(var(--cui-content-125), 0.750);
+		--cui-toned-border-color--pressed: rgb(var(--cui-content-700));
+		/* TonedControl:pressed = FilledControl:pressed */
+		--cui-toned-control-color--pressed: rgb(var(--cui-controls-700));
+		--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-125), 0.750);
+		--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-700));
 	}
 	.scheme-dark-above, .scheme-dark-above *:not([class*="scheme-"]),
 	.scheme-system-above, .scheme-system-above *:not([class*="scheme-"]) {
 		/* Content */
-		--cui-background-color: rgb(var(--cui-content-125));
-		--cui-background-color--above: rgb(var(--cui-content-175));
-		--cui-background-color--below: rgb(var(--cui-content-75));
-		--cui-color: rgba(var(--cui-content-925), 0.750);
-		--cui-color--strong: rgb(var(--cui-content-925));
-		--cui-color--high: rgba(var(--cui-content-925), 0.750);
-		--cui-color--medium: rgba(var(--cui-content-925), 0.500);
-		--cui-color--low: rgba(var(--cui-content-925), 0.300);
-		--cui-color--lower: rgba(var(--cui-content-925), 0.125);
+		--cui-background-color: rgb(var(--cui-content-75));
+		--cui-background-color--above: rgb(var(--cui-content-100));
+		--cui-background-color--below: rgb(var(--cui-content-50));
+		--cui-color: rgba(var(--cui-content-1000), 0.750);
+		--cui-color--strong: rgb(var(--cui-content-1000));
+		--cui-color--high: rgba(var(--cui-content-1000), 0.750);
+		--cui-color--medium: rgba(var(--cui-content-1000), 0.500);
+		--cui-color--low: rgba(var(--cui-content-1000), 0.300);
+		--cui-color--lower: rgba(var(--cui-content-1000), 0.125);
 
-		/* Control – 125 : 625*/
-		--cui-control-color: rgb(var(--cui-controls-625));
-		--cui-control-background-color: rgba(var(--cui-controls-125), 0.00);
+		/* Control – 75 : 650*/
+		--cui-control-color: rgb(var(--cui-controls-650));
+		--cui-control-background-color: rgba(var(--cui-controls-0), 0.250);
 		--cui-control-border-color: rgb(var(--cui-controls-625));
 
-		/* Control:highlighted – 125 : 1025 */
-		--cui-control-color--highlighted: rgb(var(--cui-controls-1000));
-		--cui-control-background-color--highlighted: rgba(var(--cui-controls-625), 0.750);
-		--cui-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+		/* Content:highlighted – 75 : 975 */
+		--cui-color--highlighted: rgb(var(--cui-content-975));
+		--cui-background-color--highlighted: rgba(var(--cui-content-325), 0.750);
+		--cui-border-color--highlighted: rgb(var(--cui-content-975));
+		/* Control:highlighted – 75 : 975 */
+		--cui-control-color--highlighted: rgb(var(--cui-controls-975));
+		--cui-control-background-color--highlighted: rgba(var(--cui-controls-325), 0.750);
+		--cui-control-border-color--highlighted: rgb(var(--cui-controls-975));
 
-		/* Control:pressed — 125 : 625 */
-		--cui-control-color--pressed: rgb(var(--cui-controls-775));
-		--cui-control-background-color--pressed: rgba(var(--cui-controls-75), 0.750);
-		--cui-control-border-color--pressed: rgb(var(--cui-controls-375));
+		/* Content:pressed — 75 : 625 */
+		--cui-color--pressed: rgb(var(--cui-content-725));
+		--cui-background-color--pressed: rgba(var(--cui-content-150), 0.750);
+		--cui-border-color--pressed: rgb(var(--cui-content-725));
+		/* Control:pressed — 75 : 625 */
+		--cui-control-color--pressed: rgb(var(--cui-controls-725));
+		--cui-control-background-color--pressed: rgba(var(--cui-controls-150), 0.750);
+		--cui-control-border-color--pressed: rgb(var(--cui-controls-725));
 
-		/* Filled — 475 : rgb(var(--cui-controls-1000)) */
-		--cui-filled-control-color: rgb(var(--cui-controls-1000));
-		--cui-filled-control-background-color: rgb(var(--cui-controls-475));
-		--cui-filled-control-border-color: rgb(var(--cui-controls-1000));
+		/* FilledContent — 175 : rgb(var(--cui-content-700)) */
+		--cui-filled-color: rgb(var(--cui-content-700));
+		--cui-filled-background-color: rgb(var(--cui-content-175));
+		--cui-filled-border-color: rgb(var(--cui-content-700));
+		/* FilledControl — 175 : rgb(var(--cui-controls-700)) */
+		--cui-filled-control-color: rgb(var(--cui-controls-700));
+		--cui-filled-control-background-color: rgb(var(--cui-controls-175));
+		--cui-filled-control-border-color: rgb(var(--cui-controls-700));
 
-		/* Filled:highlighted – 575 : 1125 */
-		--cui-filled-control-color--highlighted: rgb(var(--cui-controls-1000));
-		--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-575));
-		--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+		/* FilledContent:highlighted – 325 : 950 */
+		--cui-filled-color--highlighted: rgb(var(--cui-content-950));
+		--cui-filled-background-color--highlighted: rgb(var(--cui-content-325));
+		--cui-filled-border-color--highlighted: rgb(var(--cui-content-950));
+		/* FilledControl:highlighted – 325 : 950 */
+		--cui-filled-control-color--highlighted: rgb(var(--cui-controls-950));
+		--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-325));
+		--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-950));
 
-		/* Filled:pressed – 75 alpha : 775 */
-		--cui-filled-control-color--pressed: rgb(var(--cui-controls-775));
-		--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-75), 0.750);
-		--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-375));
+		/* FilledContent:pressed – 150 alpha : 725 */
+		--cui-filled-color--pressed: rgb(var(--cui-content-725));
+		--cui-filled-background-color--pressed: rgba(var(--cui-content-150), 0.750);
+		--cui-filled-border-color--pressed: rgb(var(--cui-content-725));
+		/* FilledControl:pressed – 150 alpha : 725 */
+		--cui-filled-control-color--pressed: rgb(var(--cui-controls-725));
+		--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-150), 0.750);
+		--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-725));
 
-		/* Toned — 325 alpha : 1025 */
-		--cui-toned-control-color: rgb(var(--cui-controls-1000));
-		--cui-toned-control-background-color: rgba(var(--cui-controls-325), 0.750);
-		--cui-toned-control-border-color: rgb(var(--cui-controls-1000));
+		/* FilledPrimaryContent — 325 : rgb(var(--cui-content-700)) */
+		--cui-filled-primary-color: rgb(var(--cui-content-950));
+		--cui-filled-primary-background-color: rgb(var(--cui-content-325));
+		--cui-filled-primary-border-color: rgb(var(--cui-content-950));
+		/* FilledPrimaryControl — 325 : rgb(var(--cui-controls-700)) */
+		--cui-filled-primary-control-color: rgb(var(--cui-controls-950));
+		--cui-filled-primary-control-background-color: rgb(var(--cui-controls-325));
+		--cui-filled-primary-control-border-color: rgb(var(--cui-controls-950));
 
-		/* Toned:highlighted = Filled:highlighted */
+		/* FilledPrimaryContent:highlighted – 425 : 1075 */
+		--cui-filled-primary-color--highlighted: rgb(var(--cui-content-1000));
+		--cui-filled-primary-background-color--highlighted: rgb(var(--cui-content-425));
+		--cui-filled-primary-border-color--highlighted: rgb(var(--cui-content-1000));
+		/* FilledPrimaryControl:highlighted – 425 : 1075 */
+		--cui-filled-primary-control-color--highlighted: rgb(var(--cui-controls-1000));
+		--cui-filled-primary-control-background-color--highlighted: rgb(var(--cui-controls-425));
+		--cui-filled-primary-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+
+		/* FilledPrimaryContent:pressed – 200 alpha : 675 */
+		--cui-filled-primary-color--pressed: rgb(var(--cui-content-675));
+		--cui-filled-primary-background-color--pressed: rgb(var(--cui-content-200));
+		--cui-filled-primary-border-color--pressed: rgb(var(--cui-content-675));
+		/* FilledPrimaryControl:pressed – 200 alpha : 675 */
+		--cui-filled-primary-control-color--pressed: rgb(var(--cui-controls-675));
+		--cui-filled-primary-control-background-color--pressed: rgb(var(--cui-controls-200));
+		--cui-filled-primary-control-border-color--pressed: rgb(var(--cui-controls-675));
+
+		/* TonedContent — 325 alpha : 925 */
+		--cui-toned-color: rgb(var(--cui-content-925));
+		--cui-toned-background-color: rgba(var(--cui-content-325), 0.250);
+		--cui-toned-border-color: rgb(var(--cui-content-925));
+		/* TonedControl — 325 alpha : 925 */
+		--cui-toned-control-color: rgb(var(--cui-controls-925));
+		--cui-toned-control-background-color: rgba(var(--cui-controls-325), 0.250);
+		--cui-toned-control-border-color: rgb(var(--cui-controls-925));
+
+		/* TonedContent:highlighted = FilledControl:highlighted */
+		--cui-toned-color--highlighted: rgb(var(--cui-content-1000));
+		--cui-toned-background-color--highlighted: rgb(var(--cui-content-425));
+		--cui-toned-border-color--highlighted: rgb(var(--cui-content-950));
+		/* TonedControl:highlighted = FilledControl:highlighted */
 		--cui-toned-control-color--highlighted: rgb(var(--cui-controls-1000));
-		--cui-toned-control-background-color--highlighted: rgb(var(--cui-controls-575));
-		--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+		--cui-toned-control-background-color--highlighted: rgba(var(--cui-controls-400), 0.875);
+		--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-950));
 
-		/* Toned:pressed = Filled:pressed */
-		--cui-toned-control-color--pressed: rgb(var(--cui-controls-775));
-		--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-75), 0.750);
-		--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-375));
+		/* TonedContent:pressed = FilledControl:pressed */
+		--cui-toned-color--pressed: rgb(var(--cui-content-725));
+		--cui-toned-background-color--pressed: rgba(var(--cui-content-150), 0.750);
+		--cui-toned-border-color--pressed: rgb(var(--cui-content-725));
+		/* TonedControl:pressed = FilledControl:pressed */
+		--cui-toned-control-color--pressed: rgb(var(--cui-controls-725));
+		--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-150), 0.750);
+		--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-725));
 	}
 	.scheme-light-below, .scheme-light-below *:not([class*="scheme-"]) {
+		/* Content */
+		--cui-background-color: rgb(var(--cui-content-925));
+		--cui-background-color--above: rgb(var(--cui-content-950));
+		--cui-background-color--below: rgb(var(--cui-content-900));
+		--cui-color: rgba(var(--cui-content-50), 0.750);
+		--cui-color--strong: rgb(var(--cui-content-50));
+		--cui-color--high: rgba(var(--cui-content-50), 0.750);
+		--cui-color--medium: rgba(var(--cui-content-50), 0.500);
+		--cui-color--low: rgba(var(--cui-content-50), 0.300);
+		--cui-color--lower: rgba(var(--cui-content-50), 0.125);
+
+		/* Control – 925 : 350*/
+		--cui-control-color: rgb(var(--cui-controls-350));
+		--cui-control-background-color: rgba(var(--cui-controls-925), 0.250);
+		--cui-control-border-color: rgb(var(--cui-controls-425));
+
+		/* Content:highlighted – 925 : 350 */
+		--cui-color--highlighted: rgb(var(--cui-content-350));
+		--cui-background-color--highlighted: rgba(var(--cui-content-1000), 0.750);
+		--cui-border-color--highlighted: rgb(var(--cui-content-350));
+		/* Control:highlighted – 925 : 350 */
+		--cui-control-color--highlighted: rgb(var(--cui-controls-350));
+		--cui-control-background-color--highlighted: rgba(var(--cui-controls-1000), 0.750);
+		--cui-control-border-color--highlighted: rgb(var(--cui-controls-350));
+
+		/* Content:pressed — 925 : 275 */
+		--cui-color--pressed: rgb(var(--cui-content-475));
+		--cui-background-color--pressed: rgba(var(--cui-content-125), 0.175);
+		--cui-border-color--pressed: rgb(var(--cui-content-475));
+		/* Control:pressed — 925 : 275 */
+		--cui-control-color--pressed: rgb(var(--cui-controls-475));
+		--cui-control-background-color--pressed: rgba(var(--cui-controls-125), 0.175);
+		--cui-control-border-color--pressed: rgb(var(--cui-controls-475));
+
+		/* FilledContent — 875 : rgb(var(--cui-content-300)) */
+		--cui-filled-color: rgb(var(--cui-content-300));
+		--cui-filled-background-color: rgb(var(--cui-content-875));
+		--cui-filled-border-color: rgb(var(--cui-content-300));
+		/* FilledControl — 875 : rgb(var(--cui-controls-300)) */
+		--cui-filled-control-color: rgb(var(--cui-controls-300));
+		--cui-filled-control-background-color: rgb(var(--cui-controls-875));
+		--cui-filled-control-border-color: rgb(var(--cui-controls-300));
+
+		/* FilledContent:highlighted – 1000 : 350 */
+		--cui-filled-color--highlighted: rgb(var(--cui-content-350));
+		--cui-filled-background-color--highlighted: rgb(var(--cui-content-1000));
+		--cui-filled-border-color--highlighted: rgb(var(--cui-content-350));
+		/* FilledControl:highlighted – 1000 : 350 */
+		--cui-filled-control-color--highlighted: rgb(var(--cui-controls-350));
+		--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-1000));
+		--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-350));
+
+		/* FilledContent:pressed – 125 alpha : 475 */
+		--cui-filled-color--pressed: rgb(var(--cui-content-475));
+		--cui-filled-background-color--pressed: rgba(var(--cui-content-125), 0.175);
+		--cui-filled-border-color--pressed: rgb(var(--cui-content-475));
+		/* FilledControl:pressed – 125 alpha : 475 */
+		--cui-filled-control-color--pressed: rgb(var(--cui-controls-475));
+		--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-125), 0.175);
+		--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-475));
+
+		/* FilledPrimaryContent — 325 : rgb(var(--cui-content-300)) */
+		--cui-filled-primary-color: rgb(var(--cui-content-925));
+		--cui-filled-primary-background-color: rgb(var(--cui-content-325));
+		--cui-filled-primary-border-color: rgb(var(--cui-content-925));
+		/* FilledPrimaryControl — 325 : rgb(var(--cui-controls-300)) */
+		--cui-filled-primary-control-color: rgb(var(--cui-controls-925));
+		--cui-filled-primary-control-background-color: rgb(var(--cui-controls-325));
+		--cui-filled-primary-control-border-color: rgb(var(--cui-controls-925));
+
+		/* FilledPrimaryContent:highlighted – 425 : 1300 */
+		--cui-filled-primary-color--highlighted: rgb(var(--cui-content-1000));
+		--cui-filled-primary-background-color--highlighted: rgb(var(--cui-content-425));
+		--cui-filled-primary-border-color--highlighted: rgb(var(--cui-content-1000));
+		/* FilledPrimaryControl:highlighted – 425 : 1300 */
+		--cui-filled-primary-control-color--highlighted: rgb(var(--cui-controls-1000));
+		--cui-filled-primary-control-background-color--highlighted: rgb(var(--cui-controls-425));
+		--cui-filled-primary-control-border-color--highlighted: rgb(var(--cui-controls-1000));
+
+		/* FilledPrimaryContent:pressed – 325 alpha : 725 */
+		--cui-filled-primary-color--pressed: rgb(var(--cui-content-725));
+		--cui-filled-primary-background-color--pressed: rgb(var(--cui-content-325));
+		--cui-filled-primary-border-color--pressed: rgb(var(--cui-content-725));
+		/* FilledPrimaryControl:pressed – 325 alpha : 725 */
+		--cui-filled-primary-control-color--pressed: rgb(var(--cui-controls-725));
+		--cui-filled-primary-control-background-color--pressed: rgb(var(--cui-controls-325));
+		--cui-filled-primary-control-border-color--pressed: rgb(var(--cui-controls-725));
+
+		/* TonedContent — 800 alpha : 225 */
+		--cui-toned-color: rgb(var(--cui-content-225));
+		--cui-toned-background-color: rgba(var(--cui-content-800), 0.500);
+		--cui-toned-border-color: rgb(var(--cui-content-225));
+		/* TonedControl — 800 alpha : 225 */
+		--cui-toned-control-color: rgb(var(--cui-controls-225));
+		--cui-toned-control-background-color: rgba(var(--cui-controls-800), 0.500);
+		--cui-toned-control-border-color: rgb(var(--cui-controls-225));
+
+		/* TonedContent:highlighted = FilledControl:highlighted */
+		--cui-toned-color--highlighted: rgb(var(--cui-content-1000));
+		--cui-toned-background-color--highlighted: rgb(var(--cui-content-425));
+		--cui-toned-border-color--highlighted: rgb(var(--cui-content-350));
+		/* TonedControl:highlighted = FilledControl:highlighted */
+		--cui-toned-control-color--highlighted: rgb(var(--cui-controls-425));
+		--cui-toned-control-background-color--highlighted: rgba(var(--cui-controls-1000), 0.750);
+		--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-350));
+
+		/* TonedContent:pressed = FilledControl:pressed */
+		--cui-toned-color--pressed: rgb(var(--cui-content-475));
+		--cui-toned-background-color--pressed: rgba(var(--cui-content-125), 0.175);
+		--cui-toned-border-color--pressed: rgb(var(--cui-content-475));
+		/* TonedControl:pressed = FilledControl:pressed */
+		--cui-toned-control-color--pressed: rgb(var(--cui-controls-475));
+		--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-125), 0.175);
+		--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-475));
+	}
+	.scheme-light,
+	.scheme-light *:not([class*="scheme-"]) {
 		/* Content */
 		--cui-background-color: rgb(var(--cui-content-950));
 		--cui-background-color--above: rgb(var(--cui-content-975));
@@ -1926,53 +2589,112 @@
 		--cui-color--low: rgba(var(--cui-content-75), 0.300);
 		--cui-color--lower: rgba(var(--cui-content-75), 0.125);
 
-		/* Control – 950 : 475*/
-		--cui-control-color: rgb(var(--cui-controls-475));
-		--cui-control-background-color: rgba(var(--cui-controls-950), 0.00);
-		--cui-control-border-color: rgb(var(--cui-controls-475));
+		/* Control – 950 : 375*/
+		--cui-control-color: rgb(var(--cui-controls-375));
+		--cui-control-background-color: rgba(var(--cui-controls-950), 0.250);
+		--cui-control-border-color: rgb(var(--cui-controls-450));
 
-		/* Control:highlighted – 950 : 575 */
-		--cui-control-color--highlighted: rgb(var(--cui-controls-575));
+		/* Content:highlighted – 950 : 375 */
+		--cui-color--highlighted: rgb(var(--cui-content-375));
+		--cui-background-color--highlighted: rgba(var(--cui-content-1000), 0.750);
+		--cui-border-color--highlighted: rgb(var(--cui-content-375));
+		/* Control:highlighted – 950 : 375 */
+		--cui-control-color--highlighted: rgb(var(--cui-controls-375));
 		--cui-control-background-color--highlighted: rgba(var(--cui-controls-1000), 0.750);
-		--cui-control-border-color--highlighted: rgb(var(--cui-controls-575));
+		--cui-control-border-color--highlighted: rgb(var(--cui-controls-375));
 
-		/* Control:pressed — 950 : 475 */
-		--cui-control-color--pressed: rgb(var(--cui-controls-550));
-		--cui-control-background-color--pressed: rgba(var(--cui-controls-1000), 0.175);
-		--cui-control-border-color--pressed: rgb(var(--cui-controls-750));
+		/* Content:pressed — 950 : 300 */
+		--cui-color--pressed: rgb(var(--cui-content-500));
+		--cui-background-color--pressed: rgba(var(--cui-content-150), 0.175);
+		--cui-border-color--pressed: rgb(var(--cui-content-500));
+		/* Control:pressed — 950 : 300 */
+		--cui-control-color--pressed: rgb(var(--cui-controls-500));
+		--cui-control-background-color--pressed: rgba(var(--cui-controls-150), 0.175);
+		--cui-control-border-color--pressed: rgb(var(--cui-controls-500));
 
-		/* Filled — 1050 : rgb(var(--cui-controls-500)) */
-		--cui-filled-control-color: rgb(var(--cui-controls-500));
-		--cui-filled-control-background-color: rgb(var(--cui-controls-1000));
-		--cui-filled-control-border-color: rgb(var(--cui-controls-500));
+		/* FilledContent — 900 : rgb(var(--cui-content-325)) */
+		--cui-filled-color: rgb(var(--cui-content-325));
+		--cui-filled-background-color: rgb(var(--cui-content-900));
+		--cui-filled-border-color: rgb(var(--cui-content-325));
+		/* FilledControl — 900 : rgb(var(--cui-controls-325)) */
+		--cui-filled-control-color: rgb(var(--cui-controls-325));
+		--cui-filled-control-background-color: rgb(var(--cui-controls-900));
+		--cui-filled-control-border-color: rgb(var(--cui-controls-325));
 
-		/* Filled:highlighted – 1150 : 600 */
-		--cui-filled-control-color--highlighted: rgb(var(--cui-controls-600));
+		/* FilledContent:highlighted – 1025 : 375 */
+		--cui-filled-color--highlighted: rgb(var(--cui-content-375));
+		--cui-filled-background-color--highlighted: rgb(var(--cui-content-1000));
+		--cui-filled-border-color--highlighted: rgb(var(--cui-content-375));
+		/* FilledControl:highlighted – 1025 : 375 */
+		--cui-filled-control-color--highlighted: rgb(var(--cui-controls-375));
 		--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-1000));
-		--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-600));
+		--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-375));
 
-		/* Filled:pressed – 1050 alpha : 550 */
-		--cui-filled-control-color--pressed: rgb(var(--cui-controls-550));
-		--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-1000), 0.175);
-		--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-750));
+		/* FilledContent:pressed – 150 alpha : 500 */
+		--cui-filled-color--pressed: rgb(var(--cui-content-500));
+		--cui-filled-background-color--pressed: rgba(var(--cui-content-150), 0.175);
+		--cui-filled-border-color--pressed: rgb(var(--cui-content-500));
+		/* FilledControl:pressed – 150 alpha : 500 */
+		--cui-filled-control-color--pressed: rgb(var(--cui-controls-500));
+		--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-150), 0.175);
+		--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-500));
 
-		/* Toned — 800 alpha : 450 */
-		--cui-toned-control-color: rgb(var(--cui-controls-450));
-		--cui-toned-control-background-color: rgba(var(--cui-controls-800), 0.500);
-		--cui-toned-control-border-color: rgb(var(--cui-controls-450));
+		/* FilledPrimaryContent — 350 : rgb(var(--cui-content-325)) */
+		--cui-filled-primary-color: rgb(var(--cui-content-950));
+		--cui-filled-primary-background-color: rgb(var(--cui-content-350));
+		--cui-filled-primary-border-color: rgb(var(--cui-content-950));
+		/* FilledPrimaryControl — 350 : rgb(var(--cui-controls-325)) */
+		--cui-filled-primary-control-color: rgb(var(--cui-controls-950));
+		--cui-filled-primary-control-background-color: rgb(var(--cui-controls-350));
+		--cui-filled-primary-control-border-color: rgb(var(--cui-controls-950));
 
-		/* Toned:highlighted = Filled:highlighted */
-		--cui-toned-control-color--highlighted: rgb(var(--cui-controls-600));
-		--cui-toned-control-background-color--highlighted: rgb(var(--cui-controls-1000));
-		--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-600));
+		/* FilledPrimaryContent:highlighted – 450 : 1325 */
+		--cui-filled-primary-color--highlighted: rgb(var(--cui-content-1000));
+		--cui-filled-primary-background-color--highlighted: rgb(var(--cui-content-450));
+		--cui-filled-primary-border-color--highlighted: rgb(var(--cui-content-1000));
+		/* FilledPrimaryControl:highlighted – 450 : 1325 */
+		--cui-filled-primary-control-color--highlighted: rgb(var(--cui-controls-1000));
+		--cui-filled-primary-control-background-color--highlighted: rgb(var(--cui-controls-450));
+		--cui-filled-primary-control-border-color--highlighted: rgb(var(--cui-controls-1000));
 
-		/* Toned:pressed = Filled:pressed */
-		--cui-toned-control-color--pressed: rgb(var(--cui-controls-550));
-		--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-1000), 0.175);
-		--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-750));
+		/* FilledPrimaryContent:pressed – 350 alpha : 750 */
+		--cui-filled-primary-color--pressed: rgb(var(--cui-content-750));
+		--cui-filled-primary-background-color--pressed: rgb(var(--cui-content-350));
+		--cui-filled-primary-border-color--pressed: rgb(var(--cui-content-750));
+		/* FilledPrimaryControl:pressed – 350 alpha : 750 */
+		--cui-filled-primary-control-color--pressed: rgb(var(--cui-controls-750));
+		--cui-filled-primary-control-background-color--pressed: rgb(var(--cui-controls-350));
+		--cui-filled-primary-control-border-color--pressed: rgb(var(--cui-controls-750));
+
+		/* TonedContent — 825 alpha : 250 */
+		--cui-toned-color: rgb(var(--cui-content-250));
+		--cui-toned-background-color: rgba(var(--cui-content-825), 0.500);
+		--cui-toned-border-color: rgb(var(--cui-content-250));
+		/* TonedControl — 825 alpha : 250 */
+		--cui-toned-control-color: rgb(var(--cui-controls-250));
+		--cui-toned-control-background-color: rgba(var(--cui-controls-825), 0.500);
+		--cui-toned-control-border-color: rgb(var(--cui-controls-250));
+
+		/* TonedContent:highlighted = FilledControl:highlighted */
+		--cui-toned-color--highlighted: rgb(var(--cui-content-1000));
+		--cui-toned-background-color--highlighted: rgb(var(--cui-content-450));
+		--cui-toned-border-color--highlighted: rgb(var(--cui-content-375));
+		/* TonedControl:highlighted = FilledControl:highlighted */
+		--cui-toned-control-color--highlighted: rgb(var(--cui-controls-450));
+		--cui-toned-control-background-color--highlighted: rgba(var(--cui-controls-1000), 0.750);
+		--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-375));
+
+		/* TonedContent:pressed = FilledControl:pressed */
+		--cui-toned-color--pressed: rgb(var(--cui-content-500));
+		--cui-toned-background-color--pressed: rgba(var(--cui-content-150), 0.175);
+		--cui-toned-border-color--pressed: rgb(var(--cui-content-500));
+		/* TonedControl:pressed = FilledControl:pressed */
+		--cui-toned-control-color--pressed: rgb(var(--cui-controls-500));
+		--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-150), 0.175);
+		--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-500));
 	}
-	.scheme-light,
-	.scheme-light *:not([class*="scheme-"]) {
+	.scheme-light-above,
+	.scheme-light-above *:not([class*="scheme-"]) {
 		/* Content */
 		--cui-background-color: rgb(var(--cui-content-975));
 		--cui-background-color--above: rgb(var(--cui-content-1000));
@@ -1984,107 +2706,108 @@
 		--cui-color--low: rgba(var(--cui-content-100), 0.300);
 		--cui-color--lower: rgba(var(--cui-content-100), 0.125);
 
-		/* Control – 975 : 500*/
-		--cui-control-color: rgb(var(--cui-controls-500));
-		--cui-control-background-color: rgba(var(--cui-controls-975), 0.00);
-		--cui-control-border-color: rgb(var(--cui-controls-500));
+		/* Control – 975 : 400*/
+		--cui-control-color: rgb(var(--cui-controls-400));
+		--cui-control-background-color: rgba(var(--cui-controls-975), 0.250);
+		--cui-control-border-color: rgb(var(--cui-controls-475));
 
-		/* Control:highlighted – 975 : 600 */
-		--cui-control-color--highlighted: rgb(var(--cui-controls-600));
+		/* Content:highlighted – 975 : 400 */
+		--cui-color--highlighted: rgb(var(--cui-content-400));
+		--cui-background-color--highlighted: rgba(var(--cui-content-1000), 0.750);
+		--cui-border-color--highlighted: rgb(var(--cui-content-400));
+		/* Control:highlighted – 975 : 400 */
+		--cui-control-color--highlighted: rgb(var(--cui-controls-400));
 		--cui-control-background-color--highlighted: rgba(var(--cui-controls-1000), 0.750);
-		--cui-control-border-color--highlighted: rgb(var(--cui-controls-600));
+		--cui-control-border-color--highlighted: rgb(var(--cui-controls-400));
 
-		/* Control:pressed — 975 : 500 */
-		--cui-control-color--pressed: rgb(var(--cui-controls-575));
-		--cui-control-background-color--pressed: rgba(var(--cui-controls-1000), 0.175);
-		--cui-control-border-color--pressed: rgb(var(--cui-controls-775));
+		/* Content:pressed — 975 : 325 */
+		--cui-color--pressed: rgb(var(--cui-content-525));
+		--cui-background-color--pressed: rgba(var(--cui-content-175), 0.175);
+		--cui-border-color--pressed: rgb(var(--cui-content-525));
+		/* Control:pressed — 975 : 325 */
+		--cui-control-color--pressed: rgb(var(--cui-controls-525));
+		--cui-control-background-color--pressed: rgba(var(--cui-controls-175), 0.175);
+		--cui-control-border-color--pressed: rgb(var(--cui-controls-525));
 
-		/* Filled — 1075 : rgb(var(--cui-controls-525)) */
-		--cui-filled-control-color: rgb(var(--cui-controls-525));
-		--cui-filled-control-background-color: rgb(var(--cui-controls-1000));
-		--cui-filled-control-border-color: rgb(var(--cui-controls-525));
+		/* FilledContent — 925 : rgb(var(--cui-content-350)) */
+		--cui-filled-color: rgb(var(--cui-content-350));
+		--cui-filled-background-color: rgb(var(--cui-content-925));
+		--cui-filled-border-color: rgb(var(--cui-content-350));
+		/* FilledControl — 925 : rgb(var(--cui-controls-350)) */
+		--cui-filled-control-color: rgb(var(--cui-controls-350));
+		--cui-filled-control-background-color: rgb(var(--cui-controls-925));
+		--cui-filled-control-border-color: rgb(var(--cui-controls-350));
 
-		/* Filled:highlighted – 1175 : 625 */
-		--cui-filled-control-color--highlighted: rgb(var(--cui-controls-625));
+		/* FilledContent:highlighted – 1050 : 400 */
+		--cui-filled-color--highlighted: rgb(var(--cui-content-400));
+		--cui-filled-background-color--highlighted: rgb(var(--cui-content-1000));
+		--cui-filled-border-color--highlighted: rgb(var(--cui-content-400));
+		/* FilledControl:highlighted – 1050 : 400 */
+		--cui-filled-control-color--highlighted: rgb(var(--cui-controls-400));
 		--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-1000));
-		--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-625));
+		--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-400));
 
-		/* Filled:pressed – 1075 alpha : 575 */
-		--cui-filled-control-color--pressed: rgb(var(--cui-controls-575));
-		--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-1000), 0.175);
-		--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-775));
+		/* FilledContent:pressed – 175 alpha : 525 */
+		--cui-filled-color--pressed: rgb(var(--cui-content-525));
+		--cui-filled-background-color--pressed: rgba(var(--cui-content-175), 0.175);
+		--cui-filled-border-color--pressed: rgb(var(--cui-content-525));
+		/* FilledControl:pressed – 175 alpha : 525 */
+		--cui-filled-control-color--pressed: rgb(var(--cui-controls-525));
+		--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-175), 0.175);
+		--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-525));
 
-		/* Toned — 825 alpha : 475 */
-		--cui-toned-control-color: rgb(var(--cui-controls-475));
-		--cui-toned-control-background-color: rgba(var(--cui-controls-825), 0.500);
-		--cui-toned-control-border-color: rgb(var(--cui-controls-475));
+		/* FilledPrimaryContent — 375 : rgb(var(--cui-content-350)) */
+		--cui-filled-primary-color: rgb(var(--cui-content-975));
+		--cui-filled-primary-background-color: rgb(var(--cui-content-375));
+		--cui-filled-primary-border-color: rgb(var(--cui-content-975));
+		/* FilledPrimaryControl — 375 : rgb(var(--cui-controls-350)) */
+		--cui-filled-primary-control-color: rgb(var(--cui-controls-975));
+		--cui-filled-primary-control-background-color: rgb(var(--cui-controls-375));
+		--cui-filled-primary-control-border-color: rgb(var(--cui-controls-975));
 
-		/* Toned:highlighted = Filled:highlighted */
-		--cui-toned-control-color--highlighted: rgb(var(--cui-controls-625));
-		--cui-toned-control-background-color--highlighted: rgb(var(--cui-controls-1000));
-		--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-625));
+		/* FilledPrimaryContent:highlighted – 475 : 1350 */
+		--cui-filled-primary-color--highlighted: rgb(var(--cui-content-1000));
+		--cui-filled-primary-background-color--highlighted: rgb(var(--cui-content-475));
+		--cui-filled-primary-border-color--highlighted: rgb(var(--cui-content-1000));
+		/* FilledPrimaryControl:highlighted – 475 : 1350 */
+		--cui-filled-primary-control-color--highlighted: rgb(var(--cui-controls-1000));
+		--cui-filled-primary-control-background-color--highlighted: rgb(var(--cui-controls-475));
+		--cui-filled-primary-control-border-color--highlighted: rgb(var(--cui-controls-1000));
 
-		/* Toned:pressed = Filled:pressed */
-		--cui-toned-control-color--pressed: rgb(var(--cui-controls-575));
-		--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-1000), 0.175);
-		--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-775));
-	}
-	.scheme-light-above,
-	.scheme-light-above *:not([class*="scheme-"]) {
-		/* Content */
-		--cui-background-color: rgb(var(--cui-content-1000));
-		--cui-background-color--above: rgb(var(--cui-content-1000));
-		--cui-background-color--below: rgb(var(--cui-content-975));
-		--cui-color: rgba(var(--cui-content-125), 0.750);
-		--cui-color--strong: rgb(var(--cui-content-125));
-		--cui-color--high: rgba(var(--cui-content-125), 0.750);
-		--cui-color--medium: rgba(var(--cui-content-125), 0.500);
-		--cui-color--low: rgba(var(--cui-content-125), 0.300);
-		--cui-color--lower: rgba(var(--cui-content-125), 0.125);
+		/* FilledPrimaryContent:pressed – 375 alpha : 775 */
+		--cui-filled-primary-color--pressed: rgb(var(--cui-content-775));
+		--cui-filled-primary-background-color--pressed: rgb(var(--cui-content-375));
+		--cui-filled-primary-border-color--pressed: rgb(var(--cui-content-775));
+		/* FilledPrimaryControl:pressed – 375 alpha : 775 */
+		--cui-filled-primary-control-color--pressed: rgb(var(--cui-controls-775));
+		--cui-filled-primary-control-background-color--pressed: rgb(var(--cui-controls-375));
+		--cui-filled-primary-control-border-color--pressed: rgb(var(--cui-controls-775));
 
-		/* Control – 1000 : 525*/
-		--cui-control-color: rgb(var(--cui-controls-525));
-		--cui-control-background-color: rgba(var(--cui-controls-1000), 0.00);
-		--cui-control-border-color: rgb(var(--cui-controls-525));
-
-		/* Control:highlighted – 1000 : 625 */
-		--cui-control-color--highlighted: rgb(var(--cui-controls-625));
-		--cui-control-background-color--highlighted: rgba(var(--cui-controls-1000), 0.750);
-		--cui-control-border-color--highlighted: rgb(var(--cui-controls-625));
-
-		/* Control:pressed — 1000 : 525 */
-		--cui-control-color--pressed: rgb(var(--cui-controls-600));
-		--cui-control-background-color--pressed: rgba(var(--cui-controls-1000), 0.175);
-		--cui-control-border-color--pressed: rgb(var(--cui-controls-800));
-
-		/* Filled — 1100 : rgb(var(--cui-controls-550)) */
-		--cui-filled-control-color: rgb(var(--cui-controls-550));
-		--cui-filled-control-background-color: rgb(var(--cui-controls-1000));
-		--cui-filled-control-border-color: rgb(var(--cui-controls-550));
-
-		/* Filled:highlighted – 1200 : 650 */
-		--cui-filled-control-color--highlighted: rgb(var(--cui-controls-650));
-		--cui-filled-control-background-color--highlighted: rgb(var(--cui-controls-1000));
-		--cui-filled-control-border-color--highlighted: rgb(var(--cui-controls-650));
-
-		/* Filled:pressed – 1100 alpha : 600 */
-		--cui-filled-control-color--pressed: rgb(var(--cui-controls-600));
-		--cui-filled-control-background-color--pressed: rgba(var(--cui-controls-1000), 0.175);
-		--cui-filled-control-border-color--pressed: rgb(var(--cui-controls-800));
-
-		/* Toned — 850 alpha : 500 */
-		--cui-toned-control-color: rgb(var(--cui-controls-500));
+		/* TonedContent — 850 alpha : 275 */
+		--cui-toned-color: rgb(var(--cui-content-275));
+		--cui-toned-background-color: rgba(var(--cui-content-850), 0.500);
+		--cui-toned-border-color: rgb(var(--cui-content-275));
+		/* TonedControl — 850 alpha : 275 */
+		--cui-toned-control-color: rgb(var(--cui-controls-275));
 		--cui-toned-control-background-color: rgba(var(--cui-controls-850), 0.500);
-		--cui-toned-control-border-color: rgb(var(--cui-controls-500));
+		--cui-toned-control-border-color: rgb(var(--cui-controls-275));
 
-		/* Toned:highlighted = Filled:highlighted */
-		--cui-toned-control-color--highlighted: rgb(var(--cui-controls-650));
-		--cui-toned-control-background-color--highlighted: rgb(var(--cui-controls-1000));
-		--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-650));
+		/* TonedContent:highlighted = FilledControl:highlighted */
+		--cui-toned-color--highlighted: rgb(var(--cui-content-1000));
+		--cui-toned-background-color--highlighted: rgb(var(--cui-content-475));
+		--cui-toned-border-color--highlighted: rgb(var(--cui-content-400));
+		/* TonedControl:highlighted = FilledControl:highlighted */
+		--cui-toned-control-color--highlighted: rgb(var(--cui-controls-475));
+		--cui-toned-control-background-color--highlighted: rgba(var(--cui-controls-1000), 0.750);
+		--cui-toned-control-border-color--highlighted: rgb(var(--cui-controls-400));
 
-		/* Toned:pressed = Filled:pressed */
-		--cui-toned-control-color--pressed: rgb(var(--cui-controls-600));
-		--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-1000), 0.175);
-		--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-800));
+		/* TonedContent:pressed = FilledControl:pressed */
+		--cui-toned-color--pressed: rgb(var(--cui-content-525));
+		--cui-toned-background-color--pressed: rgba(var(--cui-content-175), 0.175);
+		--cui-toned-border-color--pressed: rgb(var(--cui-content-525));
+		/* TonedControl:pressed = FilledControl:pressed */
+		--cui-toned-control-color--pressed: rgb(var(--cui-controls-525));
+		--cui-toned-control-background-color--pressed: rgba(var(--cui-controls-175), 0.175);
+		--cui-toned-control-border-color--pressed: rgb(var(--cui-controls-525));
 	}
 }

--- a/packages/ui/src/types/ButtonDistinction.ts
+++ b/packages/ui/src/types/ButtonDistinction.ts
@@ -1,3 +1,3 @@
 import type { Default } from './Default'
 
-export type ButtonDistinction = Default | 'toned' | 'outlined' | 'seamless'
+export type ButtonDistinction = Default | 'primary' | 'toned' | 'outlined' | 'seamless'

--- a/packages/ui/stories/src/Button.stories.tsx
+++ b/packages/ui/stories/src/Button.stories.tsx
@@ -6,7 +6,7 @@ const intents: Intent[] = ['default', 'primary', 'secondary', 'tertiary', 'posit
 const schemes: Scheme[] = ['system', 'light', 'light-above', 'light-below', 'dark', 'dark-above', 'dark-below']
 const sizes: Size[] = ['default', 'small', 'large']
 const flows: ButtonFlow[] = ['default', 'circular', 'squarish', 'generous', 'block', 'generousBlock']
-const distinctions: ButtonDistinction[] = ['default', 'toned', 'outlined', 'seamless']
+const distinctions: ButtonDistinction[] = ['default', 'primary', 'toned', 'outlined', 'seamless']
 const justifications: Justification[] = ['default', 'justifyStart', 'justifyCenter', 'justifyEnd']
 
 export default {


### PR DESCRIPTION
Adds primary button distinction & removes hacks; desaturates menu

**Changes:**

- Dark theme contrasts
- Light theme colours
- Primary buttons distinction
- Only active, hovered & focus items use control colours

Closes https://github.com/contember/private-issues/issues/84 

### Checks
- [x] The changes and implementation strategy have been consulted with the maintainers.
- [x] The code passes all the checks (Run `pnpm run check`).
