### PR TITLE
Editor: Allow block splitting in references

### DIFF
--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -62,9 +62,9 @@
 		"react-select": "4.3.1",
 		"react-sortable-hoc": "2.0.0",
 		"react-window": "1.8.6",
-		"slate": "0.66.5",
+		"slate": "0.73.1",
 		"slate-history": "0.66.0",
-		"slate-react": "0.67.0",
+		"slate-react": "0.74.0",
 		"stacktracey": "2.1.7"
 	},
 	"peerDependencies": {

--- a/packages/admin/src/components/bindingFacade/richText/blockEditor/editor/overrideInsertBreak.ts
+++ b/packages/admin/src/components/bindingFacade/richText/blockEditor/editor/overrideInsertBreak.ts
@@ -1,5 +1,8 @@
 import type { EditorWithBlocks } from './EditorWithBlocks'
 import { isInReferenceElement } from '../utils'
+import { ContemberEditor } from '../../ContemberEditor'
+import { isElementWithReference } from '../elements'
+import { Editor, Transforms, Text, Element, Path as SlatePath } from 'slate'
 
 export interface OverrideInsertBreakOptions {}
 
@@ -7,9 +10,42 @@ export const overrideInsertBreak = <E extends EditorWithBlocks>(editor: E, optio
 	const { insertBreak } = editor
 
 	editor.insertBreak = () => {
+		const closestBlockEntry = ContemberEditor.closestBlockEntry(editor)
+		if (closestBlockEntry && isElementWithReference(closestBlockEntry[0])) {
+			const selection = editor.selection
+			const [, closestBlockPath] = closestBlockEntry
+			const [referenceStart, referenceEnd] = Editor.edges(editor, closestBlockPath)
+
+			if (!selection) {
+				return
+			}
+
+			return Editor.withoutNormalizing(editor, () => {
+				Transforms.wrapNodes(editor, editor.createDefaultElement([]), {
+					at: {
+						anchor: referenceStart,
+						focus: referenceEnd,
+					},
+					match: node => Text.isText(node) || (Element.isElement(node) && editor.isInline(node)),
+				})
+
+				const relative = SlatePath.relative(selection.focus.path, closestBlockPath)
+				Transforms.splitNodes(editor, {
+					// The zero should be the newly created default element.
+					at: {
+						path: [...closestBlockPath, 0, ...relative],
+						offset: selection.focus.offset,
+					},
+					always: true,
+				})
+			})
+		}
+
+		// Do not split reference nodes
 		if (isInReferenceElement(editor)) {
 			return
 		}
+
 		return insertBreak()
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,9 +134,9 @@ importers:
       react-sortable-hoc: 2.0.0
       react-test-renderer: ^17
       react-window: 1.8.6
-      slate: 0.66.5
+      slate: 0.73.1
       slate-history: 0.66.0
-      slate-react: 0.67.0
+      slate-react: 0.74.0
       stacktracey: 2.1.7
     dependencies:
       '@contember/binding': link:../binding
@@ -164,9 +164,9 @@ importers:
       react-select: 4.3.1_7510db4ec16e957d3f42221e7066b6f6
       react-sortable-hoc: 2.0.0_react-dom@17.0.2+react@17.0.2
       react-window: 1.8.6_react-dom@17.0.2+react@17.0.2
-      slate: 0.66.5
-      slate-history: 0.66.0_slate@0.66.5
-      slate-react: 0.67.0_c899868e5f2c1eaf0ddf5188fc03f066
+      slate: 0.73.1
+      slate-history: 0.66.0_slate@0.73.1
+      slate-react: 0.74.0_7f0474d2f1224a2fc7a4a9e23b38a268
       stacktracey: 2.1.7
     devDependencies:
       '@contember/schema': 1.0.0-rc.15
@@ -14854,17 +14854,17 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /slate-history/0.66.0_slate@0.66.5:
+  /slate-history/0.66.0_slate@0.73.1:
     resolution: {integrity: sha512-6MWpxGQZiMvSINlCbMW43E2YBSVMCMCIwQfBzGssjWw4kb0qfvj0pIdblWNRQZD0hR6WHP+dHHgGSeVdMWzfng==}
     peerDependencies:
       slate: '>=0.65.3'
     dependencies:
       is-plain-object: 5.0.0
-      slate: 0.66.5
+      slate: 0.73.1
     dev: false
 
-  /slate-react/0.67.0_c899868e5f2c1eaf0ddf5188fc03f066:
-    resolution: {integrity: sha512-aJDqDskN2Ny1Q2bUFmM9qG000BbDLkA8+pIsrK9Z30glmS7je+KWoR29zdHe2s/fuKRLVayxcvs+q1VQzc1dfw==}
+  /slate-react/0.74.0_7f0474d2f1224a2fc7a4a9e23b38a268:
+    resolution: {integrity: sha512-L5fEuwfUQN61Hhxk2NBoh2teaZj653j3pzA2svEopk3G7E9Zt7MNssuLsH8PZ3YB/+Y+xQJZ3hkkrLX9wamxLg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -14879,12 +14879,12 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       scroll-into-view-if-needed: 2.2.28
-      slate: 0.66.5
+      slate: 0.73.1
       tiny-invariant: 1.0.6
     dev: false
 
-  /slate/0.66.5:
-    resolution: {integrity: sha512-bG03uEKIm/gS6jQarKSNbHn2anemOON2vnSI3VGRd7MJJU5Yiwmutze0yHNO9uZwDLTB+LeDQYZeGu1ACWT0VA==}
+  /slate/0.73.1:
+    resolution: {integrity: sha512-MpBbw14g7D2expa9F2/hRRVucwl9jYDJp4qWC2NPGrDCJ6O0X1tWfxja5oVedWQDjfBj/QQFPx00EKxNQTn12A==}
     dependencies:
       immer: 9.0.6
       is-plain-object: 5.0.0


### PR DESCRIPTION
- Editor: Allow node break inside reference ContentOutlet
- Upgrade slate

Closes #

### Checks
- [ ] The changes and implementation strategy have been consulted with the maintainers.
- [ ] The code passes all the checks (Run `pnpm run check`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/admin/207)
<!-- Reviewable:end -->
