### PR TITLE
Theme class pseudo states

### DIFF
--- a/packages/admin/src/components/bindingFacade/collections/helpers/DeleteEntityButton.tsx
+++ b/packages/admin/src/components/bindingFacade/collections/helpers/DeleteEntityButton.tsx
@@ -1,5 +1,5 @@
 import { EntityAccessor, useEntity, useMutationState } from '@contember/binding'
-import { Button, ButtonOwnProps, ButtonProps, Icon } from '@contember/ui'
+import { Button, ButtonOwnProps, ButtonProps, Icon, toThemeClass } from '@contember/ui'
 import classNames from 'classnames'
 import { memo, ReactNode, useCallback } from 'react'
 import { usePersistWithFeedback } from '../../../ui'
@@ -39,8 +39,7 @@ export const DeleteEntityButton = memo((props: DeleteEntityButtonProps) => {
 	return (
 		<Button distinction="primary" {...defaultProps} {...rest} className={classNames(
 			className,
-			'theme-grey-controls',
-			'theme-danger-controls:hover',
+			toThemeClass(null, 'danger', ':hover'),
 		)} disabled={isMutating || rest.disabled} onClick={onClick}>
 			{children || <Icon blueprintIcon="trash" />}
 		</Button>

--- a/packages/admin/src/components/bindingFacade/collections/helpers/DeleteEntityButton.tsx
+++ b/packages/admin/src/components/bindingFacade/collections/helpers/DeleteEntityButton.tsx
@@ -37,10 +37,17 @@ export const DeleteEntityButton = memo((props: DeleteEntityButtonProps) => {
 	}
 
 	return (
-		<Button distinction="primary" {...defaultProps} {...rest} className={classNames(
-			className,
-			toThemeClass(null, 'danger', ':hover'),
-		)} disabled={isMutating || rest.disabled} onClick={onClick}>
+		<Button
+			distinction="primary"
+			{...defaultProps}
+			{...rest}
+			className={classNames(
+				className,
+				toThemeClass(null, 'danger', ':hover'),
+			)}
+			disabled={isMutating || rest.disabled}
+			onClick={onClick}
+		>
 			{children || <Icon blueprintIcon="trash" />}
 		</Button>
 	)

--- a/packages/ui/src/utils/toThemeClass.ts
+++ b/packages/ui/src/utils/toThemeClass.ts
@@ -2,16 +2,16 @@ import { Intent } from '../types'
 
 const REQUIRED_THEME_CLASS = 'cui-theme'
 
-export const toThemeClass = <T extends string = Intent>(contentTheme: T | null | undefined, controlsTheme: T | null | undefined): string | undefined => {
+export const toThemeClass = <T extends string = Intent>(contentTheme: T | null | undefined, controlsTheme: T | null | undefined, suffix: string = ''): string | undefined => {
   if (contentTheme === controlsTheme) {
     const both = contentTheme
 
-    return both ? `${REQUIRED_THEME_CLASS} theme-${both}` : undefined
+    return both ? `${REQUIRED_THEME_CLASS} theme-${both}${suffix}` : undefined
   }
 
   return [
     REQUIRED_THEME_CLASS,
-    contentTheme ? `theme-${contentTheme}-content` : undefined,
-    controlsTheme ? `theme-${controlsTheme}-controls` : undefined,
+    contentTheme ? `theme-${contentTheme}-content${suffix}` : undefined,
+    controlsTheme ? `theme-${controlsTheme}-controls${suffix}` : undefined,
   ].filter(Boolean).join(' ')
 }


### PR DESCRIPTION
Add missing option to apply pseudo state only theme with `:hover` or `:active` (or any other available in the future) suffixes.