### PR TITLE
Revert z-index

### DIFF
--- a/packages/ui/src/components/RepeaterItemContainer/RepeaterItemContainer.sass
+++ b/packages/ui/src/components/RepeaterItemContainer/RepeaterItemContainer.sass
@@ -31,8 +31,8 @@
 		margin-right: -.5em
 		margin-top: -.5em
 
-
 	&.is-active,
 	&:focus-within
 		color: var(--cui-control-color)
 		background-image: var(--cui-box-background-focused-overlay)
+		z-index: 1


### PR DESCRIPTION
Fixes repeater item hiding behind the repeater while dragging

Does not affect z-index fixes of 845253721ba206a5d7a9b7f7431fabdc00a1593e
Removing `z-index: 2` was too much. Changing to `z-index: 1` still works as expected in both scenarios.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/admin/284)
<!-- Reviewable:end -->
