### PR TITLE
Unify menu item in the light and dark scheme

### DIFF
--- a/packages/ui/src/components/Menu/Menu.sass
+++ b/packages/ui/src/components/Menu/Menu.sass
@@ -21,8 +21,8 @@
 		--cui-inset-vertical: calc(1.5 * var(--cui-gap))
 		--cui-inset-horizontal: calc(1.5 * var(--cui-gap-horizontal))
 	.is-active > .#{$cui-conf-globalPrefix}label
-		background-color: var(--cui-toned-control-background-color--highlighted)
-		color: var(--cui-toned-control-color--highlighted)
+		background-color: var(--cui-filled-background-color)
+		color: var(--cui-control-color)
 
 	&-expand-toggle
 		--cui-expand-toggle-size: calc(5 * var(--cui-gap))


### PR DESCRIPTION
Unifies menu item colours following the fix of the default button intent PR #272 

https://user-images.githubusercontent.com/387611/164646911-d1730733-b75c-447c-a5d7-08cd72ad1603.mov

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/admin/285)
<!-- Reviewable:end -->
