### PR TITLE
Fix repeater stacking context

### DIFF
--- a/packages/admin-sandbox/admin/components/ContentField.tsx
+++ b/packages/admin-sandbox/admin/components/ContentField.tsx
@@ -11,6 +11,7 @@ import {
 	RichEditor,
 	Scheme,
 	scrollTargetToolbarButton,
+	SelectField,
 	tableToolbarButton,
 	TextField,
 } from '@contember/admin'
@@ -123,6 +124,11 @@ export const ContentField = Component<ContentFieldProps>(
 					{ value: 'right', label: 'Right' },
 					{ value: 'center', label: 'Center' },
 				]} orientation={'horizontal'} />
+				<SelectField field={'align	'} label={'Align'} options={[
+					{ value: 'left', label: 'Left' },
+					{ value: 'right', label: 'Right' },
+					{ value: 'center', label: 'Center' },
+				]} />
 			</Block>
 			<Block discriminateBy="quote" label="Quote">
 				<BlockEditor.ContentOutlet />

--- a/packages/admin-sandbox/admin/components/Navigation.tsx
+++ b/packages/admin-sandbox/admin/components/Navigation.tsx
@@ -8,6 +8,7 @@ export const Navigation = () => (
 			<Menu.Item title="Categories" to="categories" />
 			<Menu.Item title="Articles" to="article/list" />
 			<Menu.Item title="Homepage" to="homepage" />
+			<Menu.Item title="Locales" to="locales" />
 			<Menu.Item title="Foo" to="random/foo" />
 			<Menu.Item title="Foo Bar">
 				<Menu.Item title="Skip this1" />

--- a/packages/admin-sandbox/admin/pages/locales.tsx
+++ b/packages/admin-sandbox/admin/pages/locales.tsx
@@ -1,0 +1,8 @@
+import { MultiEditPage, TextField } from '@contember/admin'
+
+export default () => (
+	<MultiEditPage entities="Locale" pageName="locales" rendererProps={{ title: 'Languages' }}>
+		<TextField label="Code" field="code" />
+		<TextField label="Label" field="label" />
+	</MultiEditPage>
+)

--- a/packages/admin-sandbox/admin/pages/tags.tsx
+++ b/packages/admin-sandbox/admin/pages/tags.tsx
@@ -3,9 +3,9 @@ import { MultiEditPage, Repeater, SelectField, TextField } from '@contember/admi
 export default () => (
 	<MultiEditPage entities="Tag" rendererProps={{ title: 'Abcd' }}>
 		<TextField field={'name'} label={'Name'} />
-		<Repeater field={'locales'} label={'Locales'} orderBy={'id'}>
-			<SelectField label={'Locale'} options={'Locale.code'} field={'locale'} />
+		<Repeater field={'locales'} label={'Locales'} sortableBy={'order'}>
 			<TextField field={'name'} label={'Name'} />
+			<SelectField label={'Locale'} options={'Locale.code'} field={'locale'} />
 		</Repeater>
 	</MultiEditPage>
 )

--- a/packages/admin-sandbox/api/migrations/2022-05-05-112442-locale-label.json
+++ b/packages/admin-sandbox/api/migrations/2022-05-05-112442-locale-label.json
@@ -1,0 +1,36 @@
+{
+	"formatVersion": 3,
+	"modifications": [
+		{
+			"modification": "createColumn",
+			"entityName": "Locale",
+			"field": {
+				"name": "label",
+				"columnName": "label",
+				"nullable": true,
+				"type": "String",
+				"columnType": "text"
+			}
+		},
+		{
+			"modification": "patchAclSchema",
+			"patch": [
+				{
+					"op": "add",
+					"path": "/roles/admin/entities/Locale/operations/create/label",
+					"value": true
+				},
+				{
+					"op": "add",
+					"path": "/roles/admin/entities/Locale/operations/update/label",
+					"value": true
+				},
+				{
+					"op": "add",
+					"path": "/roles/admin/entities/Locale/operations/read/label",
+					"value": true
+				}
+			]
+		}
+	]
+}

--- a/packages/admin-sandbox/api/migrations/2022-05-05-145615-locales-order.json
+++ b/packages/admin-sandbox/api/migrations/2022-05-05-145615-locales-order.json
@@ -1,0 +1,36 @@
+{
+	"formatVersion": 3,
+	"modifications": [
+		{
+			"modification": "createColumn",
+			"entityName": "TagLocale",
+			"field": {
+				"name": "order",
+				"columnName": "order",
+				"nullable": true,
+				"type": "Integer",
+				"columnType": "integer"
+			}
+		},
+		{
+			"modification": "patchAclSchema",
+			"patch": [
+				{
+					"op": "add",
+					"path": "/roles/admin/entities/TagLocale/operations/create/order",
+					"value": true
+				},
+				{
+					"op": "add",
+					"path": "/roles/admin/entities/TagLocale/operations/update/order",
+					"value": true
+				},
+				{
+					"op": "add",
+					"path": "/roles/admin/entities/TagLocale/operations/read/order",
+					"value": true
+				}
+			]
+		}
+	]
+}

--- a/packages/admin-sandbox/api/model/Article.ts
+++ b/packages/admin-sandbox/api/model/Article.ts
@@ -39,4 +39,5 @@ export class TagLocale {
 	tag = d.manyHasOne(Tag, 'locales')
 	locale = d.manyHasOne(Locale)
 	name = d.stringColumn().notNull()
+	order = d.intColumn()
 }

--- a/packages/admin-sandbox/api/model/Locale.ts
+++ b/packages/admin-sandbox/api/model/Locale.ts
@@ -2,4 +2,5 @@ import { SchemaDefinition as d } from '@contember/schema-definition'
 
 export class Locale {
 	code = d.stringColumn().unique().notNull()
+	label = d.stringColumn()
 }

--- a/packages/ui/src/components/ActionableBox/ActionableBox.sass
+++ b/packages/ui/src/components/ActionableBox/ActionableBox.sass
@@ -31,4 +31,7 @@
 	&:focus-within > * > &-actions
 		opacity: 1
 		pointer-events: all
+
+	&:hover > * > &-actions,
+	&:focus-within > * > &-actions
 		transform: translateY(0)

--- a/packages/ui/src/components/Forms/FieldContainer/FieldContainer.sass
+++ b/packages/ui/src/components/Forms/FieldContainer/FieldContainer.sass
@@ -45,7 +45,8 @@
 		flex: 1 1 calc(100% / 7 * 5)
 
 	&-body-content
-		//
+		> [contenteditable="false"]
+			display: contents
 	&-body-content-description
 		font-weight: 500
 		color: var(--cui-color--medium)

--- a/packages/ui/src/components/Forms/FieldContainer/FieldContainer.tsx
+++ b/packages/ui/src/components/Forms/FieldContainer/FieldContainer.tsx
@@ -69,7 +69,7 @@ export const FieldContainer = memo(
 						{description && <span className={`${componentClassName}-body-content-description`}>{description}</span>}
 					</div>}
 				</LabelElement>
-				{!!errors && (
+				{!!errors && errors.length > 0 && (
 					<div className={`${componentClassName}-errors`}>
 						<ErrorList errors={errors} />
 					</div>

--- a/packages/ui/src/components/Forms/FieldSet/FieldSet.sass
+++ b/packages/ui/src/components/Forms/FieldSet/FieldSet.sass
@@ -1,6 +1,7 @@
 .#{$cui-conf-globalPrefix}fieldSet
 	display: flex
 	flex-direction: column
+	row-gap: calc(2 * var(--cui-gap-vertical))
 
-	&-heading + &-content
-		margin-top: .75em
+	&-content > [contenteditable="false"]
+		display: contents

--- a/packages/ui/src/styles/components/editorBlockBoundary.sass
+++ b/packages/ui/src/styles/components/editorBlockBoundary.sass
@@ -33,9 +33,6 @@
 
 	&.view-beforeBlock
 		margin-top: calc(-1 * var(--cui-editor-block-boundary-height))
-		& + *
-			position: relative
-			z-index: 1
 		& + *:not(.#{$cui-conf-globalPrefix}editorTable)
 			display: flex
 			flex-direction: column


### PR DESCRIPTION
**Fix consists of `ActionableBox` selectors split:**

- Removes unnecessary stacking context caused by `transform`
- Removes `z-index` override within Editor Block

How to confirm functionality:

1. Navigate to **Homepage**
2. Add at least 2 image blocks
3. Click select of the Align field in the first block
4. Confirm position of the option is above the second block

Closes: #304 

---

_Other updates and fixes_

**Sandbox:**

- Improve model of `Locale` and `TagLocale`
- Add Locales page
- Make `TagLocale` sorbable (Tags page)
- Show align radio buttons field also as select in `FieldContainer` (for testing)

**Extra fixes:**

- `FieldContainer`: Hide errors if array is empty
- Handle wrapped elements in `FieldContainer` & `FieldSet` with `contenteditable="false"` as those should not create extra layout causing gap not to function

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/admin/313)
<!-- Reviewable:end -->
