### PR TITLE
FieldContainer: Opt-out from one-column forms layout

### DIFF
--- a/packages/ui/src/components/Forms/FieldContainer/FieldContainer.sass
+++ b/packages/ui/src/components/Forms/FieldContainer/FieldContainer.sass
@@ -7,7 +7,10 @@
 	flex-direction: column
 	row-gap: calc(2 * var(--cui-gap-vertical))
 
-	.#{$cui-conf-globalPrefix}layout-page-content-wrap &
+	&.width-fluid
+		max-width: 100%
+
+	.#{$cui-conf-globalPrefix}layout-page-content-wrap &.width-column
 		min-width: var(--cui-field-container-min-width)
 	.#{$cui-conf-globalPrefix}layout-page-content-wrap & &
 		min-width: unset

--- a/packages/ui/src/components/Forms/FieldContainer/FieldContainer.tsx
+++ b/packages/ui/src/components/Forms/FieldContainer/FieldContainer.tsx
@@ -1,33 +1,32 @@
 import classNames from 'classnames'
 import { memo, ReactNode } from 'react'
 import { useClassNamePrefix } from '../../../auxiliary'
-import type { Size } from '../../../types'
-import { toEnumViewClass, toThemeClass } from '../../../utils'
+import type { NativeProps, Size } from '../../../types'
+import { toEnumClass, toEnumViewClass, toThemeClass } from '../../../utils'
 import { Stack, StackProps } from '../../Stack'
 import { Description } from '../../Typography/Description'
 import { Label } from '../../Typography/Label'
 import { ErrorList, ErrorListProps } from '../ErrorList'
 import type { FieldContainerLabelPosition } from './Types'
 
-export interface FieldContainerProps extends ErrorListProps {
-	label: ReactNode
+export interface FieldContainerProps extends ErrorListProps, Pick<NativeProps<HTMLDivElement>, 'className' | 'style'> {
 	children: ReactNode // The actual field
+	description?: ReactNode // Can explain e.g. the kinds of values to be filled
 	direction?: StackProps['direction']
 	gap?: Size | 'none'
-
-	size?: Size
-	labelPosition?: FieldContainerLabelPosition
-
+	label: ReactNode
 	labelDescription?: ReactNode // Expands on the label e.g. to provide the additional explanation
-	description?: ReactNode // Can explain e.g. the kinds of values to be filled
-
+	labelPosition?: FieldContainerLabelPosition
+	width?: 'column' | 'fluid' | 'none'
 	required?: boolean
+	size?: Size
 	useLabelElement?: boolean
 }
 
 export const FieldContainer = memo(
 	({
 		children,
+		className,
 		description,
 		direction = 'vertical',
 		errors,
@@ -35,20 +34,27 @@ export const FieldContainer = memo(
 		label,
 		labelDescription,
 		labelPosition,
+		width = 'column',
 		required,
 		size,
 		useLabelElement = true,
+		...rest
 	}: FieldContainerProps) => {
 		const LabelElement = useLabelElement ? 'label' : 'div'
 		const componentClassName = `${useClassNamePrefix()}field-container`
 
 		return (
-			<div className={classNames(
-				`${componentClassName}`,
-				toEnumViewClass(size),
-				toEnumViewClass(labelPosition),
-				errors?.length ? toThemeClass(null, 'danger') : null,
-			)}>
+			<div
+				{...rest}
+				className={classNames(
+					`${componentClassName}`,
+					toEnumViewClass(size),
+					toEnumViewClass(labelPosition),
+					toEnumClass('width-', width === 'none' ? undefined : width),
+					errors?.length ? toThemeClass(null, 'danger') : null,
+					className,
+				)}
+			>
 				<LabelElement className={`${componentClassName}-label`}>
 					{(label || labelDescription) && <span className={`${componentClassName}-header`}>
 							{label && <Label>


### PR DESCRIPTION
- Add backward compatible optional `layout` prop
- Extend `HTMLDivElement`

Closes: https://github.com/contember/private-issues/issues/103

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/admin/325)
<!-- Reviewable:end -->
