### PR TITLE
Fix seamless select

### DIFF
--- a/packages/admin/src/tenant/components/member/EditMembership.tsx
+++ b/packages/admin/src/tenant/components/member/EditMembership.tsx
@@ -66,7 +66,7 @@ export const EditMembership: FC<EditMembershipProps> = ({ project, memberships, 
 										<Stack align="center" direction="horizontal" gap="none">
 											<Select
 												required
-												distinction="seamless"
+												distinction="seamless-with-padding"
 												onChange={role => {
 													if (typeof role === 'string' && (!membership || role !== membership.role)) {
 														updateMembership({ role, variables: [] })

--- a/packages/ui/src/components/Forms/Select/Select.sass
+++ b/packages/ui/src/components/Forms/Select/Select.sass
@@ -4,6 +4,8 @@
 	@extend %controlStates
 	@extend %controlVariants
 
+	--select-min-height: calc(var(--cui-min-height) - 2 * var(--cui-control-border-width))
+
 	appearance: none
 	-moz-appearance: none
 	-webkit-appearance: none
@@ -11,8 +13,8 @@
 	padding-right: var(--cui-padding-horizontal)
 	&:not(.view-rows)
 		padding-right: var(--cui-min-height)
-	padding-bottom: calc((var(--cui-min-height) - var(--cui-control-line-height) * 1em) / 2)
-	padding-top: calc((var(--cui-min-height) - var(--cui-control-line-height) * 1em) / 2)
+	padding-bottom: calc((var(--select-min-height) - var(--cui-control-line-height) * 1em) / 2)
+	padding-top: calc((var(--select-min-height) - var(--cui-control-line-height) * 1em) / 2)
 
 	&::-ms-expand
 		display: none

--- a/packages/ui/src/styles/abstract/controlVariants.sass
+++ b/packages/ui/src/styles/abstract/controlVariants.sass
@@ -41,14 +41,14 @@
 
 	&.view-seamless,
 	&.view-seamless-with-padding
-		background: transparent
-		border-color: transparent
+		--input-control-background: transparent
+		--input-control-border-color: transparent
 
 		&:focus
-			--input-control--background: var(--cui-background-color--above)
+			--input-control-background: var(--cui-background-color--above)
 			box-shadow: none
 		&:focus-within
-			--input-control--background: var(--cui-background-color--above)
+			--input-control-background: var(--cui-background-color--above)
 			box-shadow: none
 		&:hover
 			--input-control-background: var(--cui-background-color--above)


### PR DESCRIPTION
Fixes:

1. seamless select having transparent background set, now omitted for focus & hover pseudo states.
2. removes extra min-height taking border-width into account on select element type

<img width="375" alt="Screenshot 2022-05-18 at 13 51 19" src="https://user-images.githubusercontent.com/387611/169032415-8f7dfc13-3c55-4d03-8aa3-8cc6d60e6e3b.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/admin/328)
<!-- Reviewable:end -->
