### PR TITLE
Collapsible: Change application of the oferflows

### DIFF
--- a/packages/ui/src/components/Collapsible/Collapsible.sass
+++ b/packages/ui/src/components/Collapsible/Collapsible.sass
@@ -1,7 +1,5 @@
 @use 'sass:math'
 
-@import '../common'
-
 .#{$cui-conf-globalPrefix}collapsible
 	$root: &
 	$transition-timing-function: ease
@@ -9,9 +7,6 @@
 	--cui-collapsible-transition-duration: var(--cui-transition-duration--fast)
 	--cui-collapsible-transition-timing-function: #{$transition-timing-function}
 	--cui-collapsible-content-height: auto
-	visibility: hidden
-	overflow: hidden
-	opacity: 0
 	display: flex
 	transition-property: height, width, opacity, visibility
 	transition-timing-function: var(--cui-collapsible-transition-timing-function)
@@ -23,8 +18,13 @@
 		--cui-collapsible-transition-timing-function: step-end
 
 	&.is-expanded
-		visibility: visible
 		opacity: 1
+		visibility: visible
+	&.is-collapsed
+		height: 0
+		opacity: 0
+		overflow: hidden
+		visibility: hidden
 
 	&.is-transitioning
 		overflow: hidden
@@ -34,8 +34,6 @@
 
 	&.view-topInsert,
 	&.view-bottomInsert
-		height: 0
-
 		&.is-expanded
 			height: var(--cui-collapsible-content-height)
 
@@ -49,7 +47,6 @@
 	&.view-leftInsert,
 	&.view-rightInsert
 		align-items: flex-start
-		height: 0
 		transition-timing-function: step-end, var(--cui-collapsible-transition-timing-function), var(--cui-collapsible-transition-timing-function), var(--cui-collapsible-transition-timing-function)
 
 		&.is-expanded

--- a/packages/ui/src/components/Collapsible/Collapsible.tsx
+++ b/packages/ui/src/components/Collapsible/Collapsible.tsx
@@ -1,8 +1,8 @@
 import cn from 'classnames'
 import { CSSProperties, memo, ReactNode, useEffect, useRef, useState } from 'react'
-import { useClassNamePrefix } from '../auxiliary'
-import type { CollapsibleTransition } from '../types'
-import { forceReflow, toEnumViewClass, toStateClass } from '../utils'
+import { useClassNamePrefix } from '../../auxiliary'
+import type { CollapsibleTransition } from '../../types'
+import { forceReflow, toEnumStateClass, toEnumViewClass, toStateClass } from '../../utils'
 
 export interface CollapsibleProps {
 	expanded: boolean
@@ -60,7 +60,7 @@ export const Collapsible = memo((props: CollapsibleProps) => {
 			className={cn(
 				`${prefix}collapsible`,
 				toEnumViewClass(props.transition, 'topInsert'),
-				toStateClass('expanded', delayedExpanded),
+				toEnumStateClass(delayedExpanded ? 'expanded' : 'collapsed'),
 				toStateClass('transitioning', isTransitioning),
 			)}
 			style={

--- a/packages/ui/src/components/Collapsible/index.sass
+++ b/packages/ui/src/components/Collapsible/index.sass
@@ -1,0 +1,1 @@
+@import 'Collapsible'

--- a/packages/ui/src/components/Collapsible/index.ts
+++ b/packages/ui/src/components/Collapsible/index.ts
@@ -1,0 +1,1 @@
+export * from './Collapsible'

--- a/packages/ui/src/components/index.sass
+++ b/packages/ui/src/components/index.sass
@@ -3,6 +3,7 @@
 @import 'Box/index'
 @import 'Breadcrumbs/index'
 @import 'Card/index'
+@import 'Collapsible/index'
 @import 'Divider/index'
 @import 'Forms/index'
 @import 'Grid/index'

--- a/packages/ui/src/styles/components/index.sass
+++ b/packages/ui/src/styles/components/index.sass
@@ -1,4 +1,3 @@
-@import './collapsible'
 @import './containerSpinner'
 @import './contentStatus'
 @import './devError'


### PR DESCRIPTION
Fixes regression of the collapsible overflows outside of the menu
while keeps nested collapsibles working in the menu.

Closes: https://github.com/contember/private-issues/issues/113

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/admin/338)
<!-- Reviewable:end -->
