### PR TITLE
Fix `RepeaterItemContainer`: Bump `z-index` for small screens

### DIFF
--- a/packages/ui/src/components/RepeaterItemContainer/RepeaterItemContainer.sass
+++ b/packages/ui/src/components/RepeaterItemContainer/RepeaterItemContainer.sass
@@ -37,4 +37,4 @@
 	&:focus-within
 		color: var(--cui-control-color)
 		background-image: var(--cui-box-background-focused-overlay)
-		z-index: 1
+		z-index: 3


### PR DESCRIPTION
Fixes hidden boxes while dragging on small screens

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/admin/378)
<!-- Reviewable:end -->
