### PR TITLE
databinding provider improvements

### DIFF
--- a/build/api/binding.api.md
+++ b/build/api/binding.api.md
@@ -58,6 +58,7 @@ export type AccessorTreeStateAction = {
 } | {
     type: 'reset';
     binding: DataBinding;
+    environment: Environment;
 };
 
 // @public (undocumented)
@@ -70,8 +71,6 @@ export interface AccessorTreeStateMetadata {
 export interface AccessorTreeStateOptions {
     // (undocumented)
     nodeTree: ReactNode;
-    // (undocumented)
-    refreshOnEnvironmentChange?: boolean;
     // (undocumented)
     refreshOnPersist?: boolean;
 }
@@ -119,8 +118,6 @@ export interface BindingConfig {
     beforeUpdateSettleLimit: number;
     // (undocumented)
     maxPersistAttempts: number;
-    // (undocumented)
-    maxSchemaLoadAttempts: number;
     // (undocumented)
     persistSuccessSettleLimit: number;
 }
@@ -183,7 +180,8 @@ export function Component<Props extends {}, NonStaticPropNames extends keyof Pro
 
 // @public (undocumented)
 export class DataBinding {
-    constructor(contentApiClient: GraphQlClient, systemApiClient: GraphQlClient, tenantApiClient: GraphQlClient, environment: Environment, onUpdate: (newData: TreeRootAccessor, binding: DataBinding) => void, onError: (error: RequestError, binding: DataBinding) => void, onPersistSuccess: (result: SuccessfulPersistResult, binding: DataBinding) => void);
+    // Warning: (ae-forgotten-export) The symbol "TreeStore" needs to be exported by the entry point index.d.ts
+    constructor(contentApiClient: GraphQlClient, systemApiClient: GraphQlClient, tenantApiClient: GraphQlClient, treeStore: TreeStore, environment: Environment, onUpdate: (newData: TreeRootAccessor, binding: DataBinding) => void, onError: (error: RequestError, binding: DataBinding) => void, onPersistSuccess: (result: SuccessfulPersistResult, binding: DataBinding) => void);
     // (undocumented)
     extendTree(newFragment: ReactNode, options?: ExtendTreeOptions): Promise<TreeRootId | undefined>;
 }
@@ -198,8 +196,6 @@ export const DataBindingProvider: <StateProps>(props: DataBindingProviderProps<S
 export interface DataBindingProviderBaseProps {
     // (undocumented)
     children?: ReactNode;
-    // (undocumented)
-    refreshOnEnvironmentChange?: boolean;
     // (undocumented)
     refreshOnPersist?: boolean;
 }
@@ -935,6 +931,8 @@ export interface ErrorAccessorTreeState {
     // (undocumented)
     binding: DataBinding;
     // (undocumented)
+    environment: Environment;
+    // (undocumented)
     error: RequestError;
     // (undocumented)
     name: 'error';
@@ -1314,13 +1312,17 @@ export interface InitializedAccessorTreeState {
     // (undocumented)
     data: TreeRootAccessor;
     // (undocumented)
+    environment: Environment;
+    // (undocumented)
     name: 'initialized';
 }
 
 // @public (undocumented)
 export interface InitializingAccessorTreeState {
     // (undocumented)
-    binding: DataBinding;
+    binding?: DataBinding;
+    // (undocumented)
+    environment: Environment;
     // (undocumented)
     name: 'initializing';
 }
@@ -2439,7 +2441,7 @@ export function useAccessorUpdateSubscription(getAccessor: () => EntityListAcces
 export const useBindingOperations: () => BindingOperations;
 
 // @public (undocumented)
-export const useDataBinding: ({ nodeTree, refreshOnEnvironmentChange, refreshOnPersist, }: AccessorTreeStateOptions) => AccessorTreeState;
+export const useDataBinding: ({ nodeTree, refreshOnPersist, }: AccessorTreeStateOptions) => AccessorTreeState;
 
 // @public @deprecated
 export const useDerivedField: <SourceValue extends FieldValue = FieldValue>(sourceField: string | SugaredRelativeSingleField, derivedField: string | SugaredRelativeSingleField, transform?: (sourceValue: SourceValue | null) => SourceValue | null, agent?: string) => void;

--- a/packages/admin/src/components/bindingFacade/environment/DimensionsSwitcher/DimensionsSwitcher.tsx
+++ b/packages/admin/src/components/bindingFacade/environment/DimensionsSwitcher/DimensionsSwitcher.tsx
@@ -55,7 +55,7 @@ export const DimensionsSwitcher = memo((props: DimensionsSwitcherProps) => {
 	const labelFactory = <Field field={props.labelField} />
 
 	return (
-		<DataBindingProvider stateComponent={DimensionsStateRenderer} refreshOnEnvironmentChange={false} key={key}>
+		<DataBindingProvider stateComponent={DimensionsStateRenderer} key={key}>
 			<EntityListSubTree
 				entities={qualifiedEntityList}
 				orderBy={qualifiedEntityList.orderBy}

--- a/packages/binding/src/accessorTree/AccessorTree.tsx
+++ b/packages/binding/src/accessorTree/AccessorTree.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { BindingOperationsProvider } from '../accessorPropagation'
+import { BindingOperationsProvider, EnvironmentContext } from '../accessorPropagation'
 import type { AccessorTreeState } from './AccessorTreeState'
 import { AccessorTreeStateContext } from './AccessorTreeStateContext'
 import { DirtinessContext } from './DirtinessContext'
@@ -11,29 +11,23 @@ export interface AccessorTreeProps {
 }
 
 export function AccessorTree({ state, children }: AccessorTreeProps) {
-	// It is *CRUCIAL* that both branches differ only in props, not structurally. Otherwise there would be far too many
-	// remounts.
-	if (state.name === 'initialized') {
-		return (
+	const stateData = state.name === 'initialized' ? state.data : {
+		hasUnpersistedChanges: false,
+		isMutating: false,
+		bindingOperations: undefined,
+	}
+	return (
+		<EnvironmentContext.Provider value={state.environment}>
 			<AccessorTreeStateContext.Provider value={state}>
-				<DirtinessContext.Provider value={state.data.hasUnpersistedChanges}>
-					<MutationStateContext.Provider value={state.data.isMutating}>
-						<BindingOperationsProvider bindingOperations={state.data.bindingOperations}>
+				<DirtinessContext.Provider value={stateData.hasUnpersistedChanges}>
+					<MutationStateContext.Provider value={stateData.isMutating}>
+						<BindingOperationsProvider bindingOperations={stateData.bindingOperations}>
 							{children}
 						</BindingOperationsProvider>
 					</MutationStateContext.Provider>
 				</DirtinessContext.Provider>
 			</AccessorTreeStateContext.Provider>
-		)
-	}
-	return (
-		<AccessorTreeStateContext.Provider value={state}>
-			<DirtinessContext.Provider value={false}>
-				<MutationStateContext.Provider value={false}>
-					<BindingOperationsProvider bindingOperations={undefined}>{children}</BindingOperationsProvider>
-				</MutationStateContext.Provider>
-			</DirtinessContext.Provider>
-		</AccessorTreeStateContext.Provider>
+		</EnvironmentContext.Provider>
 	)
 }
 

--- a/packages/binding/src/accessorTree/AccessorTreeState.ts
+++ b/packages/binding/src/accessorTree/AccessorTreeState.ts
@@ -1,22 +1,29 @@
 import type { TreeRootAccessor } from '../accessors'
 import type { RequestError } from './RequestError'
 import { DataBinding } from '../core'
+import { Environment } from '../dao'
 
 export interface InitializingAccessorTreeState {
-	binding: DataBinding
 	name: 'initializing'
+	environment: Environment
+	binding?: DataBinding
 }
 
 export interface InitializedAccessorTreeState {
-	binding: DataBinding
 	name: 'initialized'
+	environment: Environment
+	binding: DataBinding
 	data: TreeRootAccessor
 }
 
 export interface ErrorAccessorTreeState {
-	binding: DataBinding
 	name: 'error'
+	environment: Environment
+	binding: DataBinding
 	error: RequestError
 }
 
-export type AccessorTreeState = InitializingAccessorTreeState | InitializedAccessorTreeState | ErrorAccessorTreeState
+export type AccessorTreeState =
+	| InitializingAccessorTreeState
+	| InitializedAccessorTreeState
+	| ErrorAccessorTreeState

--- a/packages/binding/src/accessorTree/AccessorTreeStateAction.ts
+++ b/packages/binding/src/accessorTree/AccessorTreeStateAction.ts
@@ -1,6 +1,7 @@
 import type { TreeRootAccessor } from '../accessors'
 import type { RequestError } from './RequestError'
 import { DataBinding } from '../core'
+import { Environment } from '../dao'
 
 export type AccessorTreeStateAction =
 	| {
@@ -16,4 +17,5 @@ export type AccessorTreeStateAction =
 	| {
 			type: 'reset'
 			binding: DataBinding
-	  }
+			environment: Environment
+	}

--- a/packages/binding/src/accessorTree/AccessorTreeStateOptions.ts
+++ b/packages/binding/src/accessorTree/AccessorTreeStateOptions.ts
@@ -2,6 +2,5 @@ import type { ReactNode } from 'react'
 
 export interface AccessorTreeStateOptions {
 	nodeTree: ReactNode
-	refreshOnEnvironmentChange?: boolean
 	refreshOnPersist?: boolean
 }

--- a/packages/binding/src/accessorTree/accessorTreeStateReducer.ts
+++ b/packages/binding/src/accessorTree/accessorTreeStateReducer.ts
@@ -11,8 +11,9 @@ export const accessorTreeStateReducer = (
 				return previousState
 			}
 			return {
-				binding: previousState.binding,
 				name: 'initialized',
+				environment: previousState.environment,
+				binding: previousState.binding,
 				data: action.data,
 			}
 		case 'failWithError':
@@ -20,14 +21,16 @@ export const accessorTreeStateReducer = (
 				return previousState
 			}
 			return {
-				binding: previousState.binding,
 				name: 'error',
+				environment: previousState.environment,
+				binding: previousState.binding,
 				error: action.error,
 			}
 		case 'reset':
 			return {
-				binding: action.binding,
 				name: 'initializing',
+				environment: action.environment,
+				binding: action.binding,
 			}
 	}
 }

--- a/packages/binding/src/accessors/BindingConfig.ts
+++ b/packages/binding/src/accessors/BindingConfig.ts
@@ -3,5 +3,4 @@ export interface BindingConfig {
 	beforePersistSettleLimit: number
 	persistSuccessSettleLimit: number
 	maxPersistAttempts: number
-	maxSchemaLoadAttempts: number
 }

--- a/packages/binding/src/core/Config.ts
+++ b/packages/binding/src/core/Config.ts
@@ -6,7 +6,6 @@ export class Config {
 		beforeUpdateSettleLimit: 20,
 		persistSuccessSettleLimit: 20,
 		maxPersistAttempts: 5,
-		maxSchemaLoadAttempts: 3,
 	}
 
 	private readonly config: BindingConfig

--- a/packages/binding/src/core/TreeStore.ts
+++ b/packages/binding/src/core/TreeStore.ts
@@ -40,10 +40,11 @@ export class TreeStore {
 	public readonly markerTrees: Map<TreeRootId | undefined, MarkerTreeRoot> = new Map()
 	public readonly subTreeStatesByRoot: Map<TreeRootId | undefined, Map<PlaceholderName, RootStateNode>> = new Map()
 
-	private _schema: Schema | undefined
 	public readonly persistedData: NormalizedPersistedData = new NormalizedPersistedData(new Map(), new Map())
 
-	public constructor() {}
+	public constructor(
+		private readonly _schema: Schema,
+	) {}
 
 	public mergeInQueryResponse(response: ReceivedDataTree, markerTree: MarkerTreeRoot): void {
 		RequestResponseNormalizer.mergeInQueryResponse(this.persistedData, response, markerTree)
@@ -51,13 +52,6 @@ export class TreeStore {
 
 	public mergeInMutationResponse(response: ReceivedDataTree, operations: SubMutationOperation[]): void {
 		RequestResponseNormalizer.mergeInMutationResponse(this.persistedData, response, operations)
-	}
-
-	public setSchema(newSchema: Schema): void {
-		// TODO
-		if (this._schema === undefined) {
-			this._schema = newSchema
-		}
 	}
 
 	public get persistedEntityData(): PersistedEntityDataStore {
@@ -69,9 +63,6 @@ export class TreeStore {
 	}
 
 	public get schema(): Schema {
-		if (this._schema === undefined) {
-			throw new BindingError(`Fatal error: failed to load api schema.`)
-		}
 		return this._schema
 	}
 

--- a/packages/binding/src/coreComponents/DataBindingProvider.tsx
+++ b/packages/binding/src/coreComponents/DataBindingProvider.tsx
@@ -3,7 +3,6 @@ import { AccessorTree, AccessorTreeState, useDataBinding } from '../accessorTree
 
 export interface DataBindingProviderBaseProps {
 	children?: ReactNode
-	refreshOnEnvironmentChange?: boolean
 	refreshOnPersist?: boolean
 }
 
@@ -26,7 +25,6 @@ export const DataBindingProvider = memo(function DataBindingProvider<StateProps 
 ) {
 	const accessorTreeState = useDataBinding({
 		nodeTree: props.children,
-		refreshOnEnvironmentChange: props.refreshOnEnvironmentChange,
 		refreshOnPersist: props.refreshOnPersist ?? false,
 	})
 

--- a/packages/binding/tests/cases/unit/core/bindingFactory.ts
+++ b/packages/binding/tests/cases/unit/core/bindingFactory.ts
@@ -12,11 +12,10 @@ import { ReactNode } from 'react'
 import { RawSchema } from '../../../../src/core/schema/RawSchema'
 
 export const createBindingWithEntitySubtree = ({ node, schema }: {node: ReactNode, schema: RawSchema}) => {
-	const treeStore = new TreeStore()
 	const finalSchema = new Schema(SchemaPreprocessor.processRawSchema(schema))
+	const treeStore = new TreeStore(finalSchema)
 	const environment = Environment.create().withSchema(finalSchema)
 	const generator = new MarkerTreeGenerator(node, environment)
-	treeStore.setSchema(finalSchema)
 	const config = new Config()
 	const eventManager = new EventManager({} as any, {} as any, config, new DirtinessTracker(), () => null, treeStore)
 	const stateInitializer = new StateInitializer(


### PR DESCRIPTION
- always refresh databinding on env change, but keep tree store
- remove refreshOnEnvironmentChange
- refresh tree store only on persist
- always pass environment with schema to databinding
- make env with schema available to all provider children

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/admin/400)
<!-- Reviewable:end -->
