### PR TITLE
Use transparent background for `SpinnerContainer` in most cases

### DIFF
--- a/packages/ui/src/components/Aether/Aether.sass
+++ b/packages/ui/src/components/Aether/Aether.sass
@@ -2,5 +2,5 @@
 	+size(100%)
 	min-width: inherit
 	min-height: inherit
-	background: var(--cui-background-color)
+	background-color: var(--cui-background-color)
 	color: var(--cui-color)

--- a/packages/ui/src/styles/components/containerSpinner.sass
+++ b/packages/ui/src/styles/components/containerSpinner.sass
@@ -1,14 +1,28 @@
 @import '../common'
 
 .#{$cui-conf-globalPrefix}containerSpinner
+	--cui-container-spinner-delay: 1000ms
 	+absolute(0)
 	+size(100%)
-	z-index: 10
+	align-items: center
 	display: flex
 	justify-content: center
-	align-items: center
+	z-index: 10
+
+	&.#{$cui-conf-globalPrefix}aether
+		animation-delay: var(cui-container-spinner-delay)
+		animation-duration: var(--cui-transition-duration)
+		animation-fill-mode: forwards
+		animation-name: dim-background
+		background: transparent
 
 	@each $name, $size in $cui-containerSpinner-sizes
 		$view: toView($name)
 		&#{$view}
 			font-size: $size
+
+@keyframes dim-background
+	from
+		background-color: transparent
+	to
+		background-color: var(--cui-background-color--highlighted)


### PR DESCRIPTION
- Slow queries will transition to dimmed background to further amplify the UI is not ready to be used while spinner is active

Closes: https://github.com/contember/private-issues/issues/129

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/admin/410)
<!-- Reviewable:end -->
