### PR TITLE
Pr/fix validation message update

### DIFF
--- a/build/api/ui.api.md
+++ b/build/api/ui.api.md
@@ -2588,7 +2588,7 @@ export function useActiveSectionsTabs(): ActiveSectionTabsMap;
 export const useChangeValidationState: ({ ref, onValidationStateChange }: {
     ref: ForwardedRef<any>;
     onValidationStateChange?: ((message: string) => void) | undefined;
-}) => () => void;
+}) => void;
 
 // @public (undocumented)
 export function useChildrenAsLabel(children: ReactNode): string | undefined;

--- a/packages/admin-sandbox/admin/pages/inputs.tsx
+++ b/packages/admin-sandbox/admin/pages/inputs.tsx
@@ -45,12 +45,12 @@ export const JsonField = SimpleRelativeSingleField<TextFieldProps, string>(
 
 export default () => (
 	<EditPage entity="InputShowcase(unique = One)" setOnCreate="(unique = One)">
-		<TextField field={'textValue'} label={'Text'} />
+		<TextField required field={'textValue'} label={'Text'} />
 		<TextField field={'notNullTextValue'} label={'Not null text'} />
 		<EmailField field={'emailValue'} label={'Your email'} />
 		<SearchField field={'searchValue'} label={'Search page'} />
 		<UrlField field={'urlValue'} label={'URL'} />
-		<SlugField derivedFrom={'textValue'} field={'slugValue'} label={'Slug with prefix'} unpersistedHardPrefix="https://www.contember.com/" linkToExternalUrl />
+		<SlugField required derivedFrom={'textValue'} field={'slugValue'} label={'Slug with prefix'} unpersistedHardPrefix="https://www.contember.com/" linkToExternalUrl />
 		<SlugField derivedFrom={'textValue'} field={'slugValue'} label={'Slug without prefix'} />
 		<TextareaField field={'multilineValue'} label={'Multiline text'} />
 		<CheckboxField field={'boolValue'} label={'Bool'} />

--- a/packages/admin/src/components/bindingFacade/fields/SelectField/SelectField.tsx
+++ b/packages/admin/src/components/bindingFacade/fields/SelectField/SelectField.tsx
@@ -97,3 +97,4 @@ export const SelectFieldInner = memo(
 		)
 	},
 )
+SelectFieldInner.displayName = 'SelectFieldInner'

--- a/packages/ui/src/components/Forms/Select/Select.tsx
+++ b/packages/ui/src/components/Forms/Select/Select.tsx
@@ -3,6 +3,7 @@ import { ComponentProps, CSSProperties, ForwardedRef, forwardRef, memo, ReactEle
 import ReactSelect, { StylesConfig, useStateManager } from 'react-select'
 import SelectClass from 'react-select/dist/declarations/src/Select'
 import { useComponentClassName } from '../../../auxiliary'
+import { noop } from '../../../utils'
 import { getPortalRoot } from '../../Portal'
 import { useInputClassName } from '../hooks/useInputClassName'
 import { useChangeValidationState } from '../hooks/useNativeInput'
@@ -120,7 +121,7 @@ const SelectComponent = <V extends any>({
 	const defaultInputValue = defaultValue?.label
 
 	const nativeValidationInput = useRef<HTMLInputElement>(null)
-	const changeValidationState = useChangeValidationState({ ref: nativeValidationInput, onValidationStateChange })
+	useChangeValidationState({ ref: nativeValidationInput, onValidationStateChange })
 
 	const reactSelectState = useStateManager<SelectOptionWithKey<V>, false, never, {}>({
 		defaultInputValue,
@@ -131,7 +132,6 @@ const SelectComponent = <V extends any>({
 			if (valueProp !== next) {
 				if (nativeValidationInput.current) {
 					nativeValidationInput.current.value = optionsWithKeys.find(option => option.value === next)?.key ?? ''
-					changeValidationState()
 				}
 				onChange?.(next)
 			}
@@ -139,7 +139,6 @@ const SelectComponent = <V extends any>({
 		onBlur: () => {
 			onBlur?.()
 			onFocusChange?.(false)
-			changeValidationState()
 		},
 		onFocus: () => {
 			onFocus?.()
@@ -174,10 +173,7 @@ const SelectComponent = <V extends any>({
 		<input
 			ref={nativeValidationInput}
 			value={value?.key ?? ''}
-			onChange={useCallback(() => {
-				console.log('change')
-				changeValidationState()
-			}, [changeValidationState])}
+			onChange={noop}
 			tabIndex={-1}
 			required={required || notNull}
 			style={nativeValidationInputStyle} />

--- a/packages/ui/src/components/Forms/hooks/useNativeInput.ts
+++ b/packages/ui/src/components/Forms/hooks/useNativeInput.ts
@@ -59,7 +59,7 @@ export function useNativeInput<E extends HTMLInputElement | HTMLTextAreaElement 
 	const ref = useRef<E>(null)
 	useImperativeHandle(forwardedRef, () => ref.current as unknown as E)
 
-	const changeValidationState = useChangeValidationState({ ref, onValidationStateChange })
+	useChangeValidationState({ ref, onValidationStateChange })
 
 	const onBlurListener = useCallback<FocusEventHandler<E>>((event => {
 		if (event.defaultPrevented) {
@@ -68,8 +68,7 @@ export function useNativeInput<E extends HTMLInputElement | HTMLTextAreaElement 
 
 		onBlur?.()
 		onFocusChange?.(false)
-		changeValidationState()
-	}), [onBlur, onFocusChange, changeValidationState])
+	}), [onBlur, onFocusChange])
 
 	const onFocusListener = useCallback<FocusEventHandler<E>>(event => {
 		onFocus?.()
@@ -121,9 +120,10 @@ export function useNativeInput<E extends HTMLInputElement | HTMLTextAreaElement 
 	}
 }
 
-export const useChangeValidationState = ({ ref, onValidationStateChange }: { ref: ForwardedRef<any>, onValidationStateChange?: (message: string) => void }) => {
+export const useChangeValidationState = ({ ref, onValidationStateChange }: { ref: ForwardedRef<any>, onValidationStateChange?: (message: string) => void }): void => {
 	const validationMessage = useRef<string>()
-	const changeValidationState = useCallback(() => {
+
+	useEffect(() => {
 		if (!(ref && typeof ref === 'object' && onValidationStateChange)) {
 			return
 		}
@@ -133,11 +133,5 @@ export const useChangeValidationState = ({ ref, onValidationStateChange }: { ref
 			validationMessage.current = message
 			onValidationStateChange(message)
 		}
-	}, [onValidationStateChange, ref])
-
-	useEffect(() => {
-		changeValidationState()
-	}, [changeValidationState])
-
-	return changeValidationState
+	})
 }


### PR DESCRIPTION
Change validation state when value changes not only on blur.

- Note that this not influence whether the error is being shown or not (e.g. show of errors eagerly on page load and disturb UX before user touched form).
- Previous implementation required user interaction to blur from input to the create validation error from native HTML `validationMessage`.

This way we can update validation errors even on value change caused by derivate from other field (e.g. slug from title).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/admin/445)
<!-- Reviewable:end -->
